### PR TITLE
 Agregar documentación CLAUDE.md para integración con Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,436 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MakerAI is an AI orchestration framework for Delphi developers (v3.2). It provides components for integrating multiple LLM providers (OpenAI, Claude, Gemini, Ollama, Groq, DeepSeek, Kimi, Grok, Mistral, Cohere, LM Studio), RAG systems (vector and graph-based), MCP servers, autonomous agents, and native ChatTools into Delphi applications. Supports Delphi 10.4 Sydney through 13 Florence (full support: 11 Alexandria+).
+
+**Official Website:** https://makerai.cimamaker.com
+
+## Building and Installation
+
+### Package Compilation Order
+Compile and install packages in this exact order:
+1. `Source/Packages/MakerAI.dpk` - Runtime core (~98 units)
+2. `Source/Packages/MakerAi.RAG.Drivers.dpk` - Database connectors (PostgreSQL)
+3. `Source/Packages/MakerAi.UI.dpk` - FMX visual components
+4. `Source/Packages/MakerAiDsg.dpk` - Design-time editors (requires VCL, DesignIDE)
+
+Group project: `Source/Packages/MakerAiGrp.groupproj`
+
+### Required Library Paths
+Add these folders to Delphi Library Path (Tools > Options > Language > Delphi > Library):
+- `Source/Agents`
+- `Source/Chat`
+- `Source/ChatUI`
+- `Source/Core`
+- `Source/Design`
+- `Source/MCPClient`
+- `Source/MCPServer`
+- `Source/Packages`
+- `Source/RAG`
+- `Source/Resources`
+- `Source/Tools`
+- `Source/Utils`
+
+### Running Demos
+Open `Demos/DemosVersion31.groupproj` in Delphi IDE to access all demo projects.
+
+### Testing MCP Servers
+```bash
+# Run demo server
+AiMCPServerDemo.exe --protocol sse --port 8080
+
+# Test via curl
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+```
+
+### Known Issues
+- MCP SSE Server is experimental (intermittent connectivity)
+- Linux compilation requires manual path adjustments
+- macOS support is incomplete (`MAKERAI_SUPPORT_MACOS = False` in version.inc)
+
+### Incomplete Features (code TODOs)
+- **Android screen capture**: Not implemented (`uMakerAi.Utils.ScreenCapture.pas`)
+- **Whisper streaming mode**: Not yet implemented
+- **Async transcription**: OpenAI async transcription mode pending
+- **OpenAI Audio streaming events**: `speech.audio.delta` and `transcript.text.delta` parsing not implemented
+- **Mistral OCR annotations**: Feature stub present but unimplemented
+- **Claude Citations (RAG nativo)**: Future implementation planned for native citation support
+- **Gemini Speech cost estimation**: Token/cost tracking not yet implemented
+
+## Architecture
+
+### Overview Diagram
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│  Application / Demos                                        │
+└──────┬──────────────────┬──────────────────┬────────────────┘
+       │                  │                  │
+┌──────v──────┐  ┌────────v────────┐  ┌──────v──────────────┐
+│  ChatUI     │  │  Agents         │  │  Design-Time (Dsg)  │
+│  TChatList  │  │  TAIAgentManager│  │  Property editors   │
+│  TChatInput │  │  TAIBlackboard  │  │  VCL + DesignIDE    │
+└──────┬──────┘  └────────┬────────┘  └──────┬──────────────┘
+       │                  │                  │
+┌──────v──────────────────v──────────────────v────────────────┐
+│  Chat Drivers                                               │
+│  OpenAI│Claude│Gemini│Ollama│Groq│Mistral│DeepSeek│Kimi│...│
+│  TAiChatConnection (universal connector via DriverName)     │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+┌──────────────────────────v──────────────────────────────────┐
+│  Core Layer                                                 │
+│  TAiChat (abstract) │ TAiMediaFile │ TAiChatMessages        │
+└──────┬───────────────────┬──────────────────┬───────────────┘
+       │                   │                  │
+┌──────v──────┐  ┌─────────v────────┐  ┌──────v──────────────┐
+│  Tools      │  │  RAG             │  │  MCP                │
+│  Functions  │  │  Vectors + Graph │  │  Client + Server    │
+│  Shell      │  │  VQL + GQL       │  │  StdIO/HTTP/SSE     │
+└─────────────┘  └──────────────────┘  └─────────────────────┘
+```
+
+### Core Layers
+
+**Core (`Source/Core/`)**: Foundation classes
+- `uMakerAi.Core.pas` - Base types: `TAiMediaFile`, `TAiFileCategory`, `TAiChatMediaSupport`, chat states
+- `uMakerAi.Chat.pas` - Abstract `TAiChat` base class for all LLM drivers
+- `uMakerAi.Chat.Messages.pas` - Message handling (`TAiChatMessage`, `TAiChatMessages`)
+- `uMakerAi.Embeddings.pas` - Embedding generation
+
+**Chat Drivers (`Source/Chat/`)**: LLM-specific implementations
+- `uMakerAi.Chat.AiConnection.pas` - `TAiChatConnection` universal connector (switch providers via `DriverName` property)
+- Provider-specific drivers: `TAiOpenChat`, `TAiClaudeChat`, `TAiGeminiChat`, `TAiOllamaChat`, `TAiGroqChat`, `TAiDeepSeekChat`, `TAiKimiChat`, `TAiGrokChat`, `TAiMistralChat`, `TCohereChat`, `TAiLMStudioChat`
+- `uMakerAi.Chat.Initializations.pas` - Driver registration and default model parameters via `TAiChatFactory`
+
+**Agents (`Source/Agents/`)**: Autonomous agent framework
+- `uMakerAi.Agents.pas` - Graph-based agent orchestration with `TAIAgentManager`, `TAIAgentsNode`, `TAIAgentsLink`
+- `TAIBlackboard` - Shared state between agent nodes
+- Link modes: `lmFanout`, `lmConditional`, `lmManual`, `lmExpression`
+
+**RAG (`Source/RAG/`)**: Retrieval-Augmented Generation
+- `uMakerAi.RAG.Vectors.pas` - Vector-based RAG with reranking
+- `uMakerAi.RAG.Graph.Core.pas` - Knowledge graph RAG engine
+- `uMakerAi.RAG.Graph.GQL.pas` - Graph query language
+- `uMakerAi.RAG.Vectors.VQL.pas` - Vector query language
+
+**MCP (`Source/MCPClient/`, `Source/MCPServer/`)**: Model Context Protocol
+- `uMakerAi.MCPClient.Core.pas` - MCP client for consuming external servers
+- Server implementations: StdIO, HTTP, SSE, Direct
+
+**Tools (`Source/Tools/`)**: Capabilities framework
+- `uMakerAi.Tools.Functions.pas` - Function calling system (`TAiFunctions`, `TAiToolsFunction`)
+- Provider tools: Whisper (STT), DALL-E, Sora (video), Veo (video via Gemini)
+- Agent tools: `TAiShell`, `TAiTextEditorTool`, `TAiComputerUseTool`
+- Tool interfaces: `IAiPdfTool`, `IAiVisionTool`, `IAiSpeechTool`, `IAiWebSearchTool`
+
+**ChatUI (`Source/ChatUI/`)**: FMX visual components
+- `TChatList` - Chat container with markdown rendering
+- `TChatInput` - Text/voice/attachment input bar
+
+### Key Design Patterns
+
+**Universal Connector Pattern**: `TAiChatConnection` abstracts provider differences. Set `DriverName` property to switch between providers without code changes.
+
+**Media File Abstraction**: `TAiMediaFile` handles images, PDFs, audio across all providers. Use `TAiFileCategory` to identify file types.
+
+**Chat State Machine**: All chats follow states defined in `TAiChatState` (acsIdle -> acsConnecting -> acsWriting -> acsToolCalling -> acsReasoning -> acsFinished/acsError). Additional states: `acsWaitingForInput` for interactive flows.
+
+**Driver Registration**: Chat drivers register via `uMakerAi.Chat.Initializations.pas` using `TAiChatFactory.Instance.RegisterUserParam()`. Custom drivers inherit from `TAiChat`.
+
+**Model Capabilities Configuration**: Model capabilities (vision, tools, reasoning) are configured per-provider and per-model in `uMakerAi.Chat.Initializations.pas` using:
+- `NativeInputFiles` - File types the model accepts natively (e.g., `[Tfc_Image]`)
+- `ChatMediaSupports` - Logical capabilities (e.g., `[Tcm_Text, Tcm_Image, Tcm_Reasoning]`)
+- `EnabledFeatures` - Features to enable for the model
+
+### Agent Graph Execution Model
+
+Agents use a directed graph with nodes (`TAIAgentsNode`) and links (`TAIAgentsLink`):
+- **Link modes**: `lmFanout` (parallel), `lmConditional` (if/else), `lmManual`, `lmExpression` (binding expressions)
+- **Join modes**: `jmAny` (first arrival wins), `jmAll` (wait for all inputs)
+- **Execution status**: `esRunning`, `esCompleted`, `esError`, `esTimeout`, `esAborted`
+- Nodes communicate via `TAIBlackboard` shared state dictionary
+
+## Key Files Reference
+
+| Task | Primary File |
+|------|-------------|
+| Add new LLM provider | `Source/Chat/uMakerAi.Chat.*.pas` (inherit from `TAiChat`) |
+| Modify function calling | `Source/Tools/uMakerAi.Tools.Functions.pas` |
+| RAG vector operations | `Source/RAG/uMakerAi.RAG.Vectors.pas` |
+| RAG graph operations | `Source/RAG/uMakerAi.RAG.Graph.Core.pas` |
+| Agent orchestration | `Source/Agents/uMakerAi.Agents.pas` |
+| MCP server creation | `Source/MCPServer/uMakerAi.MCPServer.Core.pas` |
+| Version/feature flags | `Source/Core/uMakerAi.Version.inc` |
+
+## Naming Conventions
+
+- Unit prefix: `uMakerAi.` (e.g., `uMakerAi.Chat.OpenAi.pas`)
+- Class prefix: `TAi` or `TAI` (e.g., `TAiChat`, `TAIAgentManager`)
+- Interface prefix: `IAi` (e.g., `IAiPdfTool`, `IAiVisionTool`)
+- Driver naming: `TAi[Provider]Chat` (e.g., `TAiOpenChat`, `TAiClaudeChat`, `TAiGeminiChat`). Exception: `TCohereChat` does not follow this convention.
+
+## Delphi Version Compatibility
+
+### Compiler Version Reference
+
+| CompilerVersion | Delphi Version | Support Level |
+|-----------------|----------------|---------------|
+| 34.0 | Delphi 10.4 Sydney | Minimum supported |
+| 35.0 | Delphi 11 Alexandria | **Full support** (primary split point) |
+| 36.0 | Delphi 12 Athens | Full support |
+| 37.0 | Delphi 13 Florence | Latest tested |
+
+### Key Conditional Split: CompilerVersion 35
+
+The codebase has 79 conditional compilation directives. The primary split is at CompilerVersion 35 (Delphi 11):
+
+- **< 35**: Uses `uJSONHelper.pas` for missing TJSONObject helper methods
+- **>= 35**: Uses native `System.JSON` helpers, `TRESTClient.SynchronizeEvents := False`
+
+```pascal
+{$IF CompilerVersion >= 34}  // Delphi 10.4 Sydney+
+  Client.SynchronizeEvents := False;
+{$IFEND}
+
+{$IF CompilerVersion < 35}
+uses uJSONHelper;  // JSON helper for older Delphi versions
+{$ENDIF}
+```
+
+### Feature Flags (uMakerAi.Version.inc)
+
+| Flag | Value | Description |
+|------|-------|-------------|
+| `MAKERAI_HAS_OPENAI` | True | OpenAI provider support |
+| `MAKERAI_HAS_WHISPER` | True | Speech-to-text |
+| `MAKERAI_HAS_EMBEDDINGS` | True | Embedding generation |
+| `MAKERAI_HAS_TOOL_CALLING` | True | Function calling framework |
+| `MAKERAI_HAS_RAG_VECTOR` | True | Vector-based RAG |
+| `MAKERAI_HAS_RAG_GRAPH` | True | Graph-based RAG |
+| `MAKERAI_HAS_MCP` | True | Model Context Protocol |
+| `MAKERAI_HAS_CHAT_CONNECTION` | True | TAiChatConnection universal connector |
+| `MAKERAI_HAS_UI_COMPONENTS` | True | FMX visual chat components |
+| `MAKERAI_HAS_AGENTS` | True | Agent orchestration |
+| `MAKERAI_SUPPORT_WINDOWS` | True | Windows platform |
+| `MAKERAI_SUPPORT_LINUX` | True | Linux platform |
+| `MAKERAI_SUPPORT_MACOS` | **False** | macOS (incomplete) |
+| `MAKERAI_SUPPORT_MOBILE` | True | Mobile (Android/iOS) |
+| `MAKERAI_API_LEVEL` | 30 | Internal API compatibility level |
+
+## Thread Safety Notes
+
+### Critical Sections (TCriticalSection)
+
+| Lock | Class | Protects |
+|------|-------|----------|
+| `FLock` | `TAiChatMessage` | Media file list operations |
+| `FLock` | `TAIBlackboard` | Shared state dictionary |
+| `FJoinLock` | `TAIAgentsLink` | Join counter for multi-input nodes |
+| `FActiveTasksLock` | `TAIAgentManager` | Active task count tracking |
+| `FOutputLock` | `TAiMCPServerStdio` | Stdout writes from multiple threads |
+| `FSessionsLock` | `TAiMCPServerSSE` | SSE session list |
+| `FCS` | `TAiVoiceMonitor` | Audio capture state |
+
+### Thread Queuing
+
+- `TThread.Queue(nil, proc)` -- used by all Chat drivers and UI components for non-blocking main-thread updates (40+ call sites)
+- `TThread.Synchronize(nil, proc)` -- used by Agents (node callbacks) and Gemini live streaming for blocking synchronization
+- `TThreadedQueue<TJSONObject>` -- async message buffering in MCP Client
+- `TThreadedQueue<string>` -- SSE outbox in MCP Server
+
+### Thread Pools
+
+- `TAIAgentManager.FThreadPool: TThreadPool` -- executes agent node callbacks on worker threads
+- Agent `OnExecute` handlers run on pool threads; use `TThread.Synchronize` to access UI
+
+### Gemini Live Streaming
+
+`TMonitor.Enter/Exit(FPendingScreenshots)` protects a shared screenshot list during Gemini's real-time video streaming.
+
+## Adding a New LLM Provider
+
+1. Create `Source/Chat/uMakerAi.Chat.[ProviderName].pas` inheriting from `TAiChat`
+2. Implement required abstract methods for API communication
+3. Register the driver in `uMakerAi.Chat.Initializations.pas`:
+   ```pascal
+   TAiChatFactory.Instance.RegisterUserParam('ProviderName', 'Max_Tokens', '8000');
+   TAiChatFactory.Instance.RegisterUserParam('ProviderName', 'NativeInputFiles', '[Tfc_Image]');
+   TAiChatFactory.Instance.RegisterUserParam('ProviderName', 'ChatMediaSupports', '[Tcm_Text, Tcm_Image]');
+   ```
+4. Add the unit to `MakerAI.dpk` package
+
+## Dependencies
+
+### External Delphi Packages Required
+
+| Dependency | Used By | Purpose |
+|------------|---------|---------|
+| `rtl` | All packages | Delphi runtime library |
+| `RESTComponents` | All packages | HTTP REST client (TRESTClient, TRESTRequest) |
+| `bindengine`, `bindcomp` | All packages | LiveBindings engine |
+| `IndySystem`, `IndyCore`, `IndyProtocols` | MakerAI.dpk | Indy HTTP/TCP for MCP StdIO and streaming |
+| `inet` | MakerAI.dpk | Internet utilities |
+| `xmlrtl` | MakerAI.dpk, RAG.Drivers | XML parsing |
+| `fmx` | MakerAi.UI.dpk | FireMonkey framework (UI components) |
+| `FireDAC`, `FireDACCommon`, `FireDACCommonDriver` | MakerAi.RAG.Drivers.dpk | Database access for PostgreSQL RAG |
+| `dbrtl` | RAG.Drivers, UI, Dsg | Database runtime |
+| `vcl` | MakerAiDsg.dpk | VCL framework (design-time editors only) |
+| `designide` | MakerAiDsg.dpk | Delphi IDE design-time integration |
+
+### Package Dependency Chain
+
+```text
+MakerAI.dpk (standalone - no internal deps)
+   ^
+   |--- MakerAi.RAG.Drivers.dpk (requires MakerAI + FireDAC)
+   |--- MakerAi.UI.dpk (requires MakerAI + FMX)
+   |--- MakerAiDsg.dpk (requires MakerAI + VCL + DesignIDE)
+```
+
+## Environment Variables
+
+API keys use the `@VAR_NAME` convention. When an API key property starts with `@`, the framework resolves it via `GetEnvironmentVariable()` at runtime. This is handled automatically in `TAiChat.ApiKey` getter and in the design-time `TParamsRegistry`.
+
+### Required Variables by Provider
+
+| Variable | Provider | Notes |
+|----------|----------|-------|
+| `OPENAI_API_KEY` | OpenAI (GPT, Whisper, DALL-E, Sora, Audio) | Default for all OpenAI endpoints |
+| `CLAUDE_API_KEY` | Anthropic Claude | |
+| `GEMINI_API_KEY` | Google Gemini (Chat, Video/Veo, Speech, WebSearch) | |
+| `OLLAMA_API_KEY` | Ollama (local) | Usually empty for local setups |
+| `GROQ_API_KEY` | Groq | |
+| `DEEPSEEK_API_KEY` | DeepSeek | |
+| `KIMI_API_KEY` | Kimi/Moonshot | |
+| `GROK_API_KEY` | xAI Grok | |
+| `MISTRAL_API_KEY` | Mistral AI | |
+| `COHERE_API_KEY` | Cohere | |
+
+### Usage
+
+```pascal
+// Automatic: set @-prefixed key, resolved at runtime
+AiConnection.ApiKey := '@OPENAI_API_KEY';
+
+// Manual: pass literal key directly
+AiConnection.ApiKey := 'sk-...';
+```
+
+## Error Handling
+
+### Custom Exception Classes
+
+| Exception | Module | When Raised |
+|-----------|--------|-------------|
+| `EVGQLParserError` | RAG/VQL | Invalid VQL syntax (lexer/parser errors) |
+| `EVGQLTranslationError` | RAG/VQL | VQL-to-SQL compilation failures |
+| `EMCPClientException` | MCPClient | MCP transport or protocol errors |
+| `EPythonArchitectureError` | Utils | Python architecture mismatch (x86 vs x64) |
+
+### Error Patterns
+
+- **Chat state machine**: Errors transition to `acsError` state; handle via `OnStateChange` event
+- **Agent graph**: Invalid graph structure (missing nodes, circular deps) raises `Exception` during `Validate()`
+- **API errors**: HTTP errors from providers are caught in `try/except` and surfaced via `OnError` events
+- Most validation uses `Exception.Create(msg)` or `Exception.CreateFmt(msg, [args])` -- catch with `on E: Exception do`
+
+## Component Selection Guide
+
+### TAiChat vs TAiChatConnection
+
+| Component | Use When | Avoid When |
+|-----------|----------|------------|
+| `TAiChatConnection` | Provider-agnostic code, switching providers at runtime via `DriverName` | You need provider-specific API features |
+| `TAi[Provider]Chat` | Direct access to provider-specific features, fine-grained control | You want portable/switchable code |
+
+### RAG: Vector vs Graph
+
+| Approach | Use When | Avoid When |
+|----------|----------|------------|
+| `TAiRAGVector` (Vector RAG) | Document Q&A, similarity search, semantic retrieval | Relationship-heavy data, traversal queries |
+| RAG Graph (`uMakerAi.RAG.Graph.Core`) | Knowledge graphs, entity relationships, traversal queries | Simple document similarity search |
+
+### MCP Server Transports
+
+| Transport | Use When | Protocol |
+|-----------|----------|----------|
+| StdIO | IDE integration, Claude Desktop, local tools | stdin/stdout |
+| HTTP | REST API integration, request/response pattern | HTTP POST |
+| SSE | Streaming responses, real-time updates (experimental) | Server-Sent Events |
+| Direct | In-process usage, no IPC overhead | Direct method calls |
+
+## Troubleshooting
+
+**Package installation fails with BPL version conflict**
+
+1. Close all Delphi instances
+2. Delete existing BPL files from Delphi's BPL output directory
+3. Recompile packages in the correct order (MakerAI -> RAG.Drivers -> UI -> Dsg)
+
+**"Unit not found" compilation errors**
+
+Verify all 12 library paths are added to Delphi Library Path (see [Required Library Paths](#required-library-paths)).
+
+**API key not resolving**
+
+Ensure the environment variable is set system-wide (not just in the current terminal). The `@VAR_NAME` syntax requires `GetEnvironmentVariable()` to find the value at runtime.
+
+**JSON parsing errors on older Delphi versions**
+
+Delphi < 11 (CompilerVersion < 35) requires `uJSONHelper.pas` in the uses clause. This is handled automatically via conditional compilation, but verify the unit is accessible in the library path.
+
+**MCP SSE Server intermittent connectivity**
+
+The SSE transport is experimental. For production use, prefer StdIO or HTTP transport.
+
+## External Documentation
+
+Detailed documentation is available in `Docs/Version 3/`:
+
+| Document | Description |
+|----------|-------------|
+| `Manual Instalacion.docx` | Installation guide |
+| `uMakerAi-ChatConnection.docx` | Complete TAiChatConnection guide with examples |
+| `uMakerAi.Chat.docx` | Core chat system reference |
+| `TAiChatClaude-Guia de Uso.docx` | Claude provider-specific guide |
+| `TAiChatGemini-Guia de Uso.docx` | Gemini provider-specific guide |
+| `uMakerAi-RAG.docx` | RAG system documentation |
+| `uMakerAI-RAGGraph.docx` | Graph RAG documentation |
+| `uMakerAi.ToolFuncions.docx` | Function calling / Tools documentation |
+| `TAiAgentes-FLUENT GRAPH BUILDER.docx` | Agent graph builder guide |
+| `uMakerAi-MCP.Server.EN.pdf` | MCP Server guide (English) |
+| `uMakerAi-MCP.Server.ES.pdf` | MCP Server guide (Spanish) |
+| `uMakerAi-Agents.ES.pdf` | Agents documentation (Spanish) |
+| `uMakerAi-RAG.ES.pdf` | RAG documentation (Spanish) |
+
+## Navigation
+
+### Source Modules
+
+| Directory | Documentation |
+|-----------|---------------|
+| [Source/](Source/CLAUDE.md) | Top-level source overview |
+| [Source/Core/](Source/Core/CLAUDE.md) | Foundation classes, TAiChat, TAiMediaFile |
+| [Source/Chat/](Source/Chat/CLAUDE.md) | LLM provider drivers |
+| [Source/Agents/](Source/Agents/CLAUDE.md) | Agent orchestration framework |
+| [Source/RAG/](Source/RAG/CLAUDE.md) | Retrieval-Augmented Generation |
+| [Source/MCPServer/](Source/MCPServer/CLAUDE.md) | MCP server implementations |
+| [Source/MCPClient/](Source/MCPClient/CLAUDE.md) | MCP client connector |
+| [Source/Tools/](Source/Tools/CLAUDE.md) | Function calling, Shell, ComputerUse |
+| [Source/ChatUI/](Source/ChatUI/CLAUDE.md) | FMX visual components |
+| [Source/Utils/](Source/Utils/CLAUDE.md) | Voice monitor, diff updater |
+| [Source/Design/](Source/Design/CLAUDE.md) | Design-time property editors |
+| [Source/Resources/](Source/Resources/CLAUDE.md) | Embedded resources |
+
+### Demos & Docs
+
+| Directory | Documentation |
+|-----------|---------------|
+| [Demos/](Demos/CLAUDE.md) | Demo projects overview |
+| [Docs/](Docs/CLAUDE.md) | Documentation index |

--- a/Demos/010-Minimalchat/CLAUDE.md
+++ b/Demos/010-Minimalchat/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MinimalChat is a Delphi FireMonkey (FMX) demonstration application showcasing integration with the MakerAI 3.x Suite - an AI orchestration framework for Delphi developers. It demonstrates two patterns for connecting to AI services (Ollama, OpenAI, Gemini, Claude, etc.).
+
+## Build & Development
+
+**IDE Required:** Delphi 11+ (Alexandria through Florence/Delphi 13)
+
+**Building:**
+- Open `MinimalChat.dproj` in Delphi IDE
+- Select target platform (Win32, Win64, Android, Android64, Linux64)
+- Build with F9 or Build menu
+
+**Output directories:** `.\$(Platform)\$(Config)` (e.g., `.\Win64\Debug\`)
+
+**Runtime dependency:** Ollama running on `localhost:11434` for local AI models
+
+## Architecture
+
+```
+MinimalChat.dpr           # Entry point - initializes FMX application
+uMainMinimalChat.pas      # Main form with AI integration logic
+uMainMinimalChat.fmx      # FireMonkey UI definition (XML)
+```
+
+**Two AI Integration Patterns Demonstrated:**
+
+1. **Direct Provider Class** (`TAiOllamaChat`):
+   ```pascal
+   AiModel := TAiOllamaChat.Create(Self);
+   AiModel.Model := 'gpt-oss:20b';
+   AiModel.Asynchronous := False;
+   Res := AiModel.AddMessageAndRun(Prompt, Role, []);
+   ```
+
+2. **Generic Connection Factory** (`TAiChatConnection`):
+   ```pascal
+   AiModel := TAiChatConnection.Create(Self);
+   AiModel.DriverName := 'Ollama';
+   AiModel.Params.Values['Url'] := 'http://localhost:11434/';
+   Res := AiModel.AddMessageAndRun(Prompt, Role, []);
+   ```
+
+## Key MakerAI Units
+
+- `uMakerAi.Chat` - Core chat functionality
+- `uMakerAi.Chat.Ollama` - Ollama provider (`TAiOllamaChat`)
+- `uMakerAi.Chat.AiConnection` - Generic connection abstraction
+- `uMakerAi.Chat.Initializations` - Framework initialization
+
+## Naming Conventions
+
+- **Classes:** `T` prefix (e.g., `TForm12`, `TAiOllamaChat`)
+- **Units:** `u` prefix (e.g., `uMainMinimalChat`, `uMakerAi.Chat`)
+- **Event handlers:** `[ComponentName][EventType]` (e.g., `BtnOllamaClick`, `AiChat1Error`)
+
+## Error Handling Pattern
+
+All AI errors route to a centralized `OnError` event:
+```pascal
+procedure TForm12.AiChat1Error(Sender: TObject; ErrorMsg: string;
+  Exception: Exception; Response: IHTTPResponse);
+begin
+  ShowMessage(ErrorMsg);
+end;
+```
+
+## Parent Project
+
+This demo is part of MakerAI 3.x Suite. Full documentation at:
+- Website: https://makerai.cimamaker.com
+- GitHub: https://github.com/gustavoeenriquez/MakerAi
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/012-ChatAllFunctions/CLAUDE.md
+++ b/Demos/012-ChatAllFunctions/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is **MakerAI 3.x**, a comprehensive AI orchestration framework for Delphi developers. It provides unified access to multiple AI providers (OpenAI GPT-5.1, Claude 4.5, Gemini 3.0, local models via Ollama/LM Studio) with support for RAG, Knowledge Graphs, MCP Servers, Agents, and Native Capability Tools.
+
+**Current directory:** Demo 012-ChatAllFunctions - A full-featured chat demo showcasing all framework capabilities.
+
+## Build System
+
+This is a Delphi project using MSBuild. Source files are `.pas` (Pascal units), `.dproj` (project files), `.dpk` (package definitions), and `.fmx` (FireMonkey forms).
+
+### Package Compilation Order
+1. `Source/Packages/MakerAI.dpk` - Main runtime package (compile first)
+2. `Source/Packages/MakerAi.RAG.Drivers.dpk` - RAG database drivers
+3. `Source/Packages/MakerAi.UI.dpk` - FireMonkey UI components
+4. `Source/Packages/MakerAiDsg.dpk` - Design-time IDE integration
+
+### Building
+- Add all `Source/*` folders to Delphi Library Path
+- Open project group `DemosVersion31.groupproj` for full demo access
+- Output goes to `.\$(Platform)\$(Config)` (e.g., `.\Win64\Debug`)
+- Supports: Win32, Win64, Android, Android64, Linux64, macOS
+
+### Requirements
+- Delphi 11 Alexandria through 13 Florence
+- Dependencies: RTL, Indy, REST Components, XML/JSON support
+- Optional: PostgreSQL client libraries for RAG PostgreSQL drivers
+
+## Architecture
+
+### Central Component: TAiChatConnection
+Provider-agnostic facade that manages driver switching, model selection, and message lifecycle. Acts as the main entry point for all AI interactions.
+
+### Core Flow
+```
+TAiChatConnection → SetDriver/Model → TAiChat (provider-specific)
+→ ProcessMessage → SendRequest → HandleResponse → UpdateUI
+```
+
+### Key Directories (from repository root)
+| Directory | Purpose |
+|-----------|---------|
+| `Source/Core/` | Base classes: TAiChat, messages, tools framework |
+| `Source/Chat/` | Provider implementations (OpenAI, Claude, Gemini, Ollama, etc.) |
+| `Source/ChatUI/` | FireMonkey visual components for chat UIs |
+| `Source/RAG/` | Vector and graph-based retrieval with VQL/GQL query languages |
+| `Source/Agents/` | Autonomous workflow orchestration |
+| `Source/Tools/` | ChatTools, native capabilities, media processing |
+| `Source/MCPServer/` | Model Context Protocol server (SSE, StdIO, DataSnap) |
+| `Source/MCPClient/` | MCP client for consuming external servers |
+| `Demos/` | 18 working examples for all major features |
+
+### Major Source Files
+- `uMakerAi.Chat.pas` (3099 lines) - Main chat orchestration
+- `uMakerAi.Chat.AiConnection.pas` - Provider-agnostic connection
+- `uMakerAi.Chat.Gemini.pas` (3937 lines) - Largest provider implementation
+- `uMakerAi.RAG.Graph.Core.pas` (4869 lines) - Knowledge graph engine
+- `uMakerAi.Agents.pas` (2890 lines) - Agent orchestration
+
+### Design Patterns
+- **Facade:** TAiChatConnection abstracts provider complexity
+- **Factory:** Provider initialization via TAiChatInitialization
+- **Strategy:** Different implementations per AI provider
+- **Observer:** Event-driven (OnReceiveData, OnCallToolFunction, etc.)
+- **Component:** TComponent-based for Delphi IDE integration
+
+## Supported AI Providers
+
+OpenAI (GPT-5.1, DALL-E 3, Sora 2, Whisper, TTS), Google Gemini (3.0, Veo 3), Anthropic Claude (4.5, computer use), DeepSeek, Groq, Ollama, LM Studio, Mistral, Kimi, Grok, Cohere
+
+## Configuration Files
+
+- `MCPConfig.mcpconf` - MCP server connections (JSON format)
+- `.dproj.local` - Local IDE settings (not committed)
+- Package `.dpk` files define module dependencies
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/014-ChatTest/CLAUDE.md
+++ b/Demos/014-ChatTest/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**MakerAI 3.x** - Enterprise Delphi AI Framework providing unified connectivity to multiple LLM providers (Claude, OpenAI GPT, Gemini, Ollama, LM Studio, Groq, DeepSeek, Mistral, Cohere) with RAG, MCP protocol support, autonomous agents, and native capability tools.
+
+**This Demo (014-ChatTest)** - Console application testing core Claude chat functionality including text chat, JSON output, JSON Schema validation, web search, code interpretation, document extraction, vision/image analysis, PDF processing, and extended thinking mode.
+
+## Build & Run
+
+**IDE**: RAD Studio (Delphi 11 Alexandria or newer)
+
+**Compile in IDE**: Open `ClaudeChatTest.dproj`, set target platform (Win32/Win64), build (F9)
+
+**Output**: `.\[Platform]\[Config]\ClaudeChatTest.exe`
+
+**Package Dependencies** (compile in this order from `Source/Packages/`):
+1. `MakerAI.dpk` - Core framework
+2. `MakerAi.RAG.Drivers.dpk` - RAG drivers
+3. `MakerAi.UI.dpk` - UI components
+4. `MakerAiDsg.dpk` - Design-time support
+
+**Runtime Requirements**:
+- API Key: Set `CLAUDE_API_KEY` environment variable or configure in code
+- Network access to `https://api.anthropic.com/v1/`
+
+## Architecture
+
+**Layered Structure**:
+```
+Connection Layer (TAiChatConnection) - Universal LLM interface, API management
+    ↓
+Chat Management (TAiChat) - Message history, context, conversation threads
+    ↓
+Core Capabilities (TAiMediaFile, TAiMessage) - Attachments, message types
+    ↓
+Tool Framework (ChatTools) - Vision, code execution, web search, file extraction
+    ↓
+Knowledge Engines (RAGVector, RAGGraph) - Semantic search, knowledge relationships
+```
+
+**Key Modules**:
+| Module | Path | Purpose |
+|--------|------|---------|
+| `uMakerAi.Chat.AiConnection` | Source/Chat/ | Main connector for all LLM operations |
+| `uMakerAi.Chat.Claude` | Source/Chat/ | Anthropic Claude driver |
+| `uMakerAi.Core` | Source/Core/ | Core types (TAiChat, TAiMediaFile, TAiMessage) |
+| `uMakerAi.Chat.Tools` | Source/Core/ | Tool/function calling framework |
+| `uMakerAi.RAG.Vectors` | Source/RAG/ | Vector embedding and search |
+| `uMakerAi.Agents` | Source/Agents/ | Agent orchestration |
+| `uMakerAi.MCPServer.Core` | Source/MCPServer/ | MCP protocol server |
+
+## Code Conventions
+
+**Unit Naming**: `uMakerAi.[Module].[SubModule].pas`
+
+**Type Naming**:
+- Classes: `TAi[Feature]` (e.g., `TAiChat`, `TAiMediaFile`)
+- Interfaces: `IAi[Feature]`
+- Events: `TOn[Event]` (e.g., `TOnChatModelChangeEvent`)
+
+**Design Patterns**:
+- Factory Pattern: Driver selection via `TAiChatConnection.DriverName`
+- Adapter Pattern: Provider-specific implementations
+- Component Pattern: `TComponent` inheritance for IDE integration
+
+## Configuration Example
+
+```pascal
+procedure ConfigureBase(A: TAiChatConnection);
+begin
+  A.DriverName := 'Claude';
+  A.Model := 'claude-sonnet-4-5-20250929';
+  A.Params.Values['ApiKey'] := '@CLAUDE_API_KEY';  // @ prefix reads from env var
+  A.Params.Values['Url'] := 'https://api.anthropic.com/v1/';
+  A.Params.Values['Max_Tokens'] := '16000';
+  A.Params.Values['Temperature'] := '0.7';
+  A.Params.Values['ResponseTimeOut'] := '600000';
+end;
+```
+
+## Demo Test Procedures
+
+The main program includes these test functions that demonstrate different capabilities:
+- `Test_Chat1()` - Basic text chat
+- `Test_JSON1()` / `Test_JSONSchema1()` - JSON formatted responses
+- `Test_WebSearch1()` - Web search integration
+- `Test_CodeInterpreter1()` - Code execution
+- `Test_ExtractText1()` / `Test_ExtractText2()` - File extraction
+- `Test_VisionImage()` - Image analysis
+- `Test_VisionPDF()` / `Test_VisionPDFJson()` - PDF processing
+- `Test_Thinking()` - Extended thinking mode
+
+## Related Demos
+
+Other demos in `/Demos/` that provide additional context:
+- `010-MinimalChat` - Simplest chat implementation
+- `012-ChatAllFunctions` - Complete function reference
+- `021-RAG+Postgres` / `022-RAG_SQLite` - RAG implementations
+- `031-MCPServer` - MCP protocol server
+- `051-AgentDemo` - Autonomous agents
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/021-RAG+Postgres-UpdateDB/CLAUDE.md
+++ b/Demos/021-RAG+Postgres-UpdateDB/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is Demo 021 of the **MakerAI 3.x Suite** - a Delphi FMX application demonstrating RAG (Retrieval-Augmented Generation) with PostgreSQL vector database integration. The demo showcases document embedding storage and semantic similarity search.
+
+## Build Commands
+
+The project uses Delphi MSBuild system:
+
+```bash
+# Build Debug (Win32)
+msbuild RagUpdateDb.dproj /p:Config=Debug /p:Platform=Win32
+
+# Build Release (Win64)
+msbuild RagUpdateDb.dproj /p:Config=Release /p:Platform=Win64
+
+# Build from Delphi IDE: Open RagUpdateDb.dproj, select configuration/platform, press F9
+```
+
+**Supported Platforms:** Win32, Win64, Android, Android64, Linux64
+
+## Architecture
+
+### Data Flow
+```
+User Query → Embedding Generation (Ollama) → Vector Search (PostgreSQL pgvector)
+→ Semantic Ranking → Context Assembly → LLM Response → UI
+```
+
+### Key Components in uRagUpdateDBMain.pas
+- `TAiOllamaEmbeddings` - Generates 768-dimension embeddings via Ollama
+- `TAiRAGVector` - RAG system for vector operations (AddData, Search)
+- `TFDConnection/TFDQuery` - FireDAC PostgreSQL connection
+- `TAiOllamaChat` - LLM chat interface for responses
+
+### Database Schema (PostgreSQL + pgvector)
+```sql
+CREATE TABLE anexos (
+  id BIGSERIAL PRIMARY KEY,
+  FechaDoc TIMESTAMP,
+  Categoria VARCHAR,
+  PathDoc VARCHAR,
+  FileName VARCHAR,
+  Resumen TEXT,
+  FileFormat VARCHAR,
+  embedding vector(768)
+);
+```
+
+## MakerAI Framework Structure
+
+The parent framework (`Source/`) provides:
+
+| Directory | Purpose |
+|-----------|---------|
+| `Chat/` | LLM provider connectors (OpenAI, Claude, Gemini, Ollama, etc.) |
+| `Core/` | Base framework classes and utilities |
+| `RAG/` | Vector and Graph RAG implementations |
+| `Tools/` | Function calling, shell, computer use, audio, image generation |
+| `Agents/` | Agent orchestration engine |
+| `MCPClient/`, `MCPServer/` | Model Context Protocol support |
+
+### Provider Pattern
+All LLM providers inherit from common interfaces:
+- `uMakerAi.Chat.AiConnection.pas` - Unified connection interface
+- Each provider (OpenAI, Claude, Gemini, Ollama) implements the same chat/embedding contracts
+
+### Event-Driven Processing
+Key callbacks used throughout:
+- `OnDataVecAddItem` - Embedding insertion complete
+- `OnDataVecSearch` - Search results returned
+- `ReceiveData` - LLM streaming response
+
+## Dependencies
+
+- **Delphi 12.2+** (Alexandria/Florence)
+- **FireDAC** - Database connectivity layer
+- **FMX** - FireMonkey cross-platform UI
+- **PostgreSQL** with **pgvector** extension enabled
+- **Ollama** (local) or other LLM provider for embeddings/chat
+
+## Working with This Codebase
+
+- UI forms use `.pas` (code) + `.fmx` (layout) pairs
+- Async operations use `TTask.Run` from System.Threading
+- Vector similarity uses pgvector's `<->` cosine distance operator
+- Comments and commit messages are in Spanish
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/022-1-RAG_SQLite/CLAUDE.md
+++ b/Demos/022-1-RAG_SQLite/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Delphi VCL demo application demonstrating RAG (Retrieval Augmented Generation) using SQLite with the vec0 vector extension for semantic similarity search.
+
+## Build Commands
+
+Open `Sqlite_RAG.dproj` in RAD Studio/Delphi IDE and build with F9 or via MSBuild:
+```bash
+msbuild Sqlite_RAG.dproj /p:Config=Release /p:Platform=Win64
+```
+
+Output: `Win64\Release\Sqlite_RAG.exe` or `Win32\Debug\Sqlite_RAG.exe`
+
+## Architecture
+
+**Single-form application** (`UMain.pas` / `UMain.dfm`):
+- Uses FireDAC for SQLite connectivity (`TFDConnection`, `TFDQuery`)
+- Integrates MakerAI library components for embeddings (`TAiOpenAiEmbeddings`)
+- Model: `text-embedding-3-small` with 1536 dimensions
+
+**Database: `vectores.db`**
+- Virtual table `vec_docs` using SQLite vec0 extension
+- Schema: `doc_id INTEGER PRIMARY KEY, tipo INTEGER, content TEXT, emb_cos FLOAT[1536], emb_l2 FLOAT[1536]`
+- Dual distance metrics: cosine and L2 (Euclidean)
+
+**Runtime Dependencies**
+- `vec0.dll` - SQLite vector search extension (must match 32/64-bit architecture)
+- `sqlite3.dll` - SQLite library
+- Both DLLs must be in same directory as executable
+
+## Key Functions
+
+- `InsertDoc()` - Inserts document with embedding into vec_docs table
+- `butSearchClick` - Performs vector similarity search using `MATCH` operator with configurable k-nearest neighbors
+- `FDConnectionAfterConnect` - Loads vec0 extension via `SELECT load_extension('vec0.dll')`
+
+## External Dependencies
+
+- **MakerAI library**: Units `uMakerAi.Embeddings.core`, `uMakerAi.Embeddings`, `uMakerAi.Chat.OpenAi`
+- Path configured via `$(MAKERAI)` environment variable in project search path
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/023-RAGVQL/CLAUDE.md
+++ b/Demos/023-RAGVQL/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+RagVQL is a Delphi FireMonkey (FMX) desktop application demonstrating advanced RAG (Retrieval-Augmented Generation) capabilities using VQL (Vector Query Language) for semantic and lexical search with PostgreSQL vector database. Part of the MakerAI 3.x AI Orchestration Framework.
+
+## Build Commands
+
+```bash
+# Using MSBuild (from command line)
+msbuild RagVectorQL.dproj /p:Config=Debug /p:Platform=Win32
+msbuild RagVectorQL.dproj /p:Config=Release /p:Platform=Win64
+
+# Using Delphi IDE
+# Open RagVectorQL.dproj, select platform, press F9
+```
+
+**Output:** `.\$(Platform)\$(Config)\` (e.g., `.\Win64\Debug\`)
+
+**Target Platforms:** Win32, Win64, Android, Android64, Linux64
+
+## Runtime Requirements
+
+- PostgreSQL with pgvector extension
+- Ollama running on `localhost:11434` for embeddings and chat
+
+## Architecture
+
+```
+RagVectorQL.dpr (Entry Point)
+└── TForm21 (uMainRAGVQL.pas)
+    ├── TAiOllamaEmbeddings       - Embedding generation (768-dim vectors)
+    ├── TAiRAGVector              - Core RAG system (vector operations)
+    ├── TAiRAGVectorPostgresDriver - PostgreSQL/pgvector integration
+    ├── TFDConnection             - FireDAC database connection
+    └── UI Components (Memos, Buttons, CheckBoxes)
+```
+
+**Data Flow:** User Query → Embedding Generation (Ollama) → Vector Search (PostgreSQL) → Ranking → Context Assembly → Display
+
+## Key MakerAI Framework Classes
+
+| Class | Unit | Purpose |
+|-------|------|---------|
+| `TAiOllamaEmbeddings` | `uMakerAi.Embeddings` | Generates embeddings via Ollama |
+| `TAiRAGVector` | `uMakerAi.rag.Vectors` | Core RAG vector operations |
+| `TAiRAGVectorPostgresDriver` | `uMakerAi.rag.Vector.Driver.Postgres` | PostgreSQL integration |
+| `TVGQLParser`, `TVGQLCompiler` | `uMakerAi.RAG.Vectors.VQL` | VQL parsing & compilation |
+| `TAiFilterCriteria` | `uMakerAi.rag.Vectors` | Advanced filtering logic |
+
+## Search Features
+
+- **UseEmbeddings:** Semantic similarity search
+- **UseBM25:** Lexical keyword search (BM25 algorithm)
+- **UseRRF:** Reciprocal Rank Fusion for hybrid results
+- **UseReorderABC:** "Lost-in-Middle" context reordering
+- **EmbeddingWeight/BM25Weight:** Score weighting in hybrid mode
+
+## Delphi Naming Conventions
+
+- **Classes:** `T` prefix (`TForm21`, `TAiRAGVector`)
+- **Units:** `u` prefix (`uMainRAGVQL`)
+- **Components:** Prefixes: `Btn*`, `Ch*`, `Lbl*`, `Memo*`, `Edit*`
+- **Event handlers:** `[Component][Event]` (`BtnConsultarClick`)
+- **Local variables:** `L` prefix (`LPrompt`, `LResponse`)
+- **Private fields:** `F` prefix (`FUserCancelled`)
+
+## Threading Pattern
+
+```pascal
+TTask.Run(procedure
+begin
+  // Background work
+  LResponse := rag.SearchText(...);
+
+  // UI update on main thread
+  TThread.Queue(nil, procedure
+  begin
+    MemoResponse.Lines.Text := LResponse;
+  end);
+end);
+```
+
+## File Formats
+
+- **.dpr** - Delphi Project Root
+- **.dproj** - MSBuild project configuration
+- **.pas** - Pascal Unit source
+- **.fmx** - FireMonkey form definition (XML)
+- **.mkVRag** - MakerAI Vector RAG file format (custom binary)
+
+## Code Language
+
+Comments and UI strings are in Spanish.
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/025-RAGGraph/CLAUDE.md
+++ b/Demos/025-RAGGraph/CLAUDE.md
@@ -1,0 +1,101 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**RagGraphDemo** is a Delphi FMX application demonstrating the MakerAI Suite's Knowledge Graph RAG engine. It combines vector similarity search with graph traversal for enhanced AI-powered information retrieval.
+
+Part of MakerAI 3.x - an AI orchestration framework for Delphi supporting multiple LLM providers (OpenAI, Gemini, Claude, Ollama, etc.).
+
+## Build Commands
+
+```bash
+# Command line (requires RAD Studio)
+msbuild RagGraphDemo.dproj /p:Config=Debug /p:Platform=Win32
+
+# Or open RagGraphDemo.dproj in Delphi IDE (11 Alexandria to 13 Florence)
+```
+
+**Platforms:** Win32, Win64, Android, Android64, Linux64
+
+## Architecture
+
+### Core Components
+
+| Component | Purpose |
+|-----------|---------|
+| `TAiRagGraph` | Main knowledge graph with in-memory or database storage |
+| `TAiRagGraphBuilder` | Converts LLM-generated JSON triplets into graph nodes/edges |
+| `TAiRagGraphPostgresDriver` | PostgreSQL persistence using pgvector for embeddings |
+| `TAiChatConnection` | LLM connection for text processing and query planning |
+
+### Data Flow
+
+1. **Text Input** → LLM extracts entities/relationships as JSON triplets
+2. **Graph Builder** → Parses JSON into nodes (entities) and edges (relationships)
+3. **Embeddings** → Generated for semantic search via TAiOllamaEmbeddings
+4. **Storage** → In-memory (.mkai) or PostgreSQL with pgvector
+5. **Query** → Hybrid search: vector similarity + lexical matching + graph traversal
+
+### Query Modes
+
+- **RAG Search** (`SearchText`): Semantic vector search with depth expansion
+- **Match Query** (`Match`): Cypher-like pattern matching via `TGraphMatchQuery`
+- **MakerGQL** (`ExecuteMakerGQL`): Custom graph query language
+- **LLM Query Planning**: LLM generates `TQueryPlan` JSON for execution
+
+### Database Events Pattern
+
+PostgreSQL mode requires implementing callback events:
+- `OnAddNode/OnAddEdge`: INSERT operations
+- `OnFindNodeByID/OnFindEdgeByID`: Lazy loading with hydration
+- `OnSearchNodes`: Vector similarity with recursive CTE for depth expansion
+- `OnGetNodeEdges`: Load connected edges
+
+### Key Source Files
+
+| File | Description |
+|------|-------------|
+| `uMainRagGraphDemo.pas` | Main form with UI handlers and database callbacks |
+| `../../Source/RAG/uMakerAi.RAG.Graph.Core.pas` | TAiRagGraphNode, TAiRagGraphEdge, TQueryPlan |
+| `../../Source/RAG/uMakerAi.RAG.Graph.Builder.pas` | JSON triplet parser |
+| `../../Source/RAG/uMakerAi.RAG.Graph.GQL.pas` | MakerGQL parser |
+
+## Key Types
+
+```pascal
+// LLM-generated graph traversal plan
+TQueryPlan = record
+  AnchorPrompt: string;      // Initial semantic search prompt
+  AnchorVariable: string;    // Starting node variable
+  ResultVariable: string;    // Return variable
+  Steps: TArray<TQueryStep>; // Traversal steps
+end;
+
+// Cypher-like pattern matching
+TGraphMatchQuery = class
+  MatchClauses: TList<TMatchClause>;
+  NodePatternByVariable: TDictionary<string, TMatchNodePattern>;
+end;
+```
+
+## File Formats
+
+- `.mkai` - Native binary graph format (optional embeddings)
+- `.graphml` - Export for Gephi, yEd
+- `.dot` - Graphviz format
+
+## Sample Data
+
+`DatosGrafo/` contains a Spanish-language story ("El Misterio de la Biblioteca Olvidada") with extracted entities (Persona, Lugar, Organizacion, Concepto) and relationships (ES_HIJO_DE, TRABAJA_EN, etc.).
+
+## Database Setup
+
+Tables: `graph_nodes`, `graph_edges`
+- Requires PostgreSQL with pgvector extension
+- Multi-tenant via `entidad` column
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/025-RAGGraph/DatosGrafo/CLAUDE.md
+++ b/Demos/025-RAGGraph/DatosGrafo/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is the **data folder** for the RAGGraph Demo (`025-RAGGraph`), which is part of the MakerAI Suite - an AI orchestration framework for Delphi. This folder contains sample data files used to demonstrate the Knowledge Graph and RAG (Retrieval-Augmented Generation) capabilities.
+
+## Folder Contents
+
+- **CuentoBibliotecaria.mkai** - Serialized MakerAI graph file with embeddings data
+- **CuentoBibliotecaria.graphml** - GraphML export for use with graph visualization tools (Gephi, yEd, Graphviz)
+- **Texto Original El Misterio de la Biblioteca Olvidada.txt** - Source text (Spanish story) used to generate the knowledge graph
+
+## Parent Demo Application
+
+The main application is in the parent folder (`025-RAGGraph/`):
+
+- **RagGraphDemo.dpr** - Main project file (Delphi FMX application)
+- **uMainRagGraphDemo.pas** - Main form unit with all demo functionality
+
+### Key Components Used
+
+```pascal
+TAiRagGraph              // Main knowledge graph component
+TAiRagGraphBuilder       // Builds graphs from JSON/LLM output
+TAiRagGraphPostgresDriver // PostgreSQL persistence driver
+TAiChatConnection        // LLM connection for entity extraction
+TAiPrompts               // Template prompts for LLM interactions
+```
+
+## File Formats
+
+### .mkai (MakerAI Graph)
+Native binary format that can include or exclude embeddings. Load/save via:
+```pascal
+RAG.LoadFromFile('graph.mkai');
+RAG.SaveToFile('graph.mkai', IncludeEmbeddings);
+```
+
+### .graphml
+Standard XML graph format for interoperability. Contains nodes with labels (Persona, Lugar, Organización, Concepto, Producto) and labeled edges representing relationships (ES_HIJO_DE, TRABAJA_EN, etc.).
+
+## Demo Workflow
+
+1. **Load text** - Import source text from `.txt` file
+2. **Process with LLM** - Use `CreaJSonFromTexto` prompt template to extract entities and relationships
+3. **Build graph** - `RAGBuilder1.Process()` parses JSON and creates nodes/edges
+4. **Search** - Semantic search via `RAG.Search()` or pattern matching via `RAG.Match()`
+5. **Query with LLM** - Use `CreaJSonQueryPlan` to generate graph queries from natural language
+6. **Export** - Save to `.mkai`, `.graphml`, `.dot`, or `.json`
+
+## Database Mode
+
+The demo supports both in-memory and PostgreSQL persistence:
+- Tables: `graph_nodes`, `graph_edges`
+- Requires pgvector extension for embedding similarity search
+- Entity isolation via `entidad` column (multi-tenant)
+
+## Navigation
+
+> See [../../CLAUDE.md](../../CLAUDE.md) for demos overview and [../../../CLAUDE.md](../../../CLAUDE.md) for project overview.

--- a/Demos/025-RAGGraph/Docs/CLAUDE.md
+++ b/Demos/025-RAGGraph/Docs/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is **RagGraphDemo**, a Delphi FMX demonstration application for the MakerAI Suite's RAG Graph functionality. It showcases a knowledge graph engine that combines vector similarity search with graph traversal for enhanced AI-powered information retrieval.
+
+The demo is part of the larger MakerAI 3.x framework - an AI orchestration suite for Delphi supporting multiple LLM providers (OpenAI, Gemini, Claude, Ollama, etc.).
+
+## Build Commands
+
+```bash
+# Build from command line using MSBuild (requires RAD Studio installed)
+msbuild RagGraphDemo.dproj /p:Config=Debug /p:Platform=Win32
+
+# Or use RAD Studio IDE to open and build:
+# Open RagGraphDemo.dproj in Delphi IDE (11 Alexandria to 13 Florence)
+```
+
+**Supported Platforms:** Win32, Win64, Android, Android64, Linux64
+
+## Architecture
+
+### Core Components
+
+- **TAiRagGraph** (`RAG`): Main knowledge graph component supporting both in-memory and database-backed storage
+- **TAiRagGraphBuilder** (`RAGBuilder1`): Converts LLM-generated JSON triplets into graph nodes and edges
+- **TAiRagGraphPostgresDriver** (`RAGPgDriver`): PostgreSQL persistence driver using pgvector for embedding storage
+- **TAiChatConnection** (`AiConn`): Connection to LLM providers for text processing and query planning
+
+### Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `uMainRagGraphDemo.pas` | Main form with all UI event handlers and database event implementations |
+| `../../Source/RAG/uMakerAi.RAG.Graph.Core.pas` | Core graph types: TAiRagGraphNode, TAiRagGraphEdge, TQueryPlan |
+| `../../Source/RAG/uMakerAi.RAG.Graph.Builder.pas` | JSON triplet parser that populates the graph |
+| `../../Source/RAG/uMakerAi.RAG.Graph.Driver.Postgres.pas` | PostgreSQL driver with pgvector support |
+| `../../Source/RAG/uMakerAi.RAG.Graph.GQL.pas` | MakerGQL query language parser |
+
+### Data Flow
+
+1. **Text Input** → LLM extracts entities/relationships as JSON triplets
+2. **Graph Builder** → Parses JSON into nodes (entities) and edges (relationships)
+3. **Embeddings** → Generated for semantic search (uses TAiOllamaEmbeddings or other providers)
+4. **Storage** → In-memory (serialized to .mkai) or PostgreSQL with pgvector
+5. **Query** → Hybrid search combining vector similarity, lexical matching, and graph traversal
+
+### Query Modes
+
+- **RAG Search** (`SearchText`): Semantic search using embeddings with optional depth expansion
+- **Match Query** (`Match`): Cypher-like pattern matching via `TGraphMatchQuery`
+- **MakerGQL** (`ExecuteMakerGQL`): Custom graph query language
+- **LLM Query Planning**: LLM generates a `TQueryPlan` JSON which is then executed
+
+### Database Events Pattern
+
+When using PostgreSQL driver, the demo implements callback events for database operations:
+- `OnAddNode`, `OnAddEdge`: INSERT into graph_nodes/graph_edges tables
+- `OnFindNodeByID`, `OnFindEdgeByID`: Lazy loading with hydration
+- `OnSearchNodes`: Vector similarity search with recursive CTE for depth expansion
+- `OnGetNodeEdges`: Load connected edges for a node
+
+## Sample Data
+
+The `Docs/` folder contains a sample Spanish-language story ("El Misterio de la Biblioteca Olvidada") used to demonstrate entity extraction and relationship mapping. The story includes characters with family relationships, work relationships, and location references - ideal for knowledge graph demonstration.
+
+## Key Types
+
+```pascal
+// Query plan for LLM-generated graph traversal
+TQueryPlan = record
+  AnchorPrompt: string;      // Initial semantic search prompt
+  AnchorVariable: string;    // Starting node variable
+  ResultVariable: string;    // Return variable
+  Steps: TArray<TQueryStep>; // Traversal steps
+end;
+
+// Pattern matching query (Cypher-like)
+TGraphMatchQuery = class
+  MatchClauses: TList<TMatchClause>;
+  NodePatternByVariable: TDictionary<string, TMatchNodePattern>;
+end;
+```
+
+## File Formats
+
+- `.mkai`: Native binary format for graph serialization (includes optional embeddings)
+- `.graphml`: Export for tools like Gephi, yEd
+- `.dot`: Graphviz format
+
+## Navigation
+
+> See [../../CLAUDE.md](../../CLAUDE.md) for demos overview and [../../../CLAUDE.md](../../../CLAUDE.md) for project overview.

--- a/Demos/026-RAGGraph-Basic/CLAUDE.md
+++ b/Demos/026-RAGGraph-Basic/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+BasicRAGGraph is a Delphi VCL demo showcasing MakerAI's graph-based RAG (Retrieval-Augmented Generation) capabilities. It demonstrates knowledge graph operations with semantic search, structural pattern matching, and hybrid queries.
+
+## Build & Run
+
+**IDE**: Delphi 11 Alexandria or newer
+
+**Build Steps**:
+1. Open `BasicRAGGraph.dproj`
+2. Ensure MakerAI `/Source/*` directories are in Library Path
+3. Compile packages in order: `MakerAI.dpk` → `MakerAi.RAG.Drivers.dpk` → `MakerAiDsg.dpk` → `MakerAi.UI.dpk`
+4. Build and run
+
+**Runtime Requirements**:
+- Ollama running locally at `http://localhost:11434/`
+- Model: `mxbai-embed-large:latest` (1024 dimensions)
+
+## Architecture
+
+### Key Components (VCL)
+- `RAG: TAiRagGraph` - Main graph database with nodes, edges, and query capabilities
+- `AiOllamaEmbeddings1: TAiOllamaEmbeddings` - Local embedding provider
+- `GraphBuilder: TAiRagGraphBuilder` - JSON-to-graph converter with merge strategies
+
+### Graph Data Model
+- **Nodes** (`TAiRagGraphNode`): Entities with labels, properties, and vector embeddings
+- **Edges** (`TAiRagGraphEdge`): Labeled relationships with optional properties
+- **Triplets**: Subject → Predicate → Object patterns
+
+### Search Modes
+1. **Semantic**: Vector-based similarity search using `RAG.Search(prompt, TopK)`
+2. **Structural**: Pattern matching with `TGraphMatchQuery` (MATCH-style clauses)
+3. **Hybrid**: Combined vector + graph traversal via `TQueryPlan`
+
+## Code Locations
+
+| File | Purpose |
+|------|---------|
+| `uMainBasicRagGraph.pas` | Main form with all demo operations |
+| `../../Source/RAG/uMakerAi.RAG.Graph.Core.pas` | Graph engine, nodes, edges, query execution |
+| `../../Source/RAG/uMakerAi.RAG.Graph.Builder.pas` | JSON import with embedding generation |
+| `../../Source/RAG/uMakerAi.RAG.Graph.GQL.pas` | Graph query language parser |
+
+## Common Operations
+
+**Add nodes manually**:
+```pascal
+Node := RAG.AddNode('Label', 'description text');
+Node.Properties.AddPair('key', 'value');
+Node.SetEmbeddings(EmbeddingsProvider.CreateEmbedding(Node.Description));
+```
+
+**Import from JSON**:
+```pascal
+GraphBuilder.ImportFromJson(JsonString, RAG, TMergeStrategy.msAddNewOnly);
+```
+
+**Semantic search**:
+```pascal
+Results := RAG.Search('query text', 10); // Top 10 similar nodes
+```
+
+**Pattern matching**:
+```pascal
+Query := TGraphMatchQuery.Create;
+Query.AddNodePattern('person', 'Person', nil);
+Query.AddEdgePattern('person', 'WORKS_AT', 'company', nil);
+Results := RAG.MatchPattern(Query);
+```
+
+## Conventions
+
+- Classes use `T` prefix (e.g., `TAiRagGraph`)
+- Framework components use `TAi` prefix
+- Merge strategies: `msAddNewOnly`, `msOverwrite`, `msKeepExisting`
+- Export formats: `gefDOT` (Graphviz), `gefGraphML` (XML), `gefGraphMkai` (native)
+
+## Related Resources
+
+- Main framework: `/Source/` directory
+- JSON structure examples: `/Source/RAG/RagGraph_Prompt_Example.md`
+- Other demos: `/Demos/025-RAGGraph/` (advanced), `/Demos/022-1-RAG_SQLite/` (vector-only)
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/031-MCPServer/CLAUDE.md
+++ b/Demos/031-MCPServer/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MakerAI MCP Server Demo - A Delphi console application demonstrating a multi-protocol MCP (Model Context Protocol) server. Part of MakerAI 3.x framework for AI integration in Delphi applications.
+
+## Build & Run
+
+**IDE:** RAD Studio (Delphi 11 Alexandria to 13 Florence)
+
+Open `AiMCPServerDemo.dproj` in RAD Studio and build for Win64/Release.
+
+**Command-line execution:**
+```bash
+# SSE protocol (default, for Claude Desktop/MakerAI clients)
+AiMCPServerDemo.exe --protocol sse --port 8080 --cors-origins "*"
+
+# Standard HTTP JSON-RPC
+AiMCPServerDemo.exe --protocol http --port 8080
+
+# Stdio (for subprocess/local integration)
+AiMCPServerDemo.exe --protocol stdio
+```
+
+## Architecture
+
+### Three-Protocol Design
+
+The server supports three transport protocols via factory pattern instantiation:
+
+1. **SSE (Server-Sent Events)** - Long-polling event stream at `/sse`, commands via POST `/messages`
+2. **HTTP** - Stateless JSON-RPC at POST `/mcp`
+3. **Stdio** - Direct stdin/stdout JSON-RPC communication
+
+### Core Classes (in /Source/MCPServer/)
+
+- `TAiMCPServer` - Abstract base server class
+- `TAiMCPLogicServer` - Tool/resource management
+- `TAiMCPToolBase<T>` - Generic base for implementing tools
+- `TAiMCPResponseBuilder` - Fluent response construction
+
+### Tool Implementation Pattern
+
+```delphi
+type
+  TMyParams = class
+    [AiMCPSchemaDescription('Parameter description')]
+    property Param: string read FParam write FParam;
+  end;
+
+  TMyTool = class(TAiMCPToolBase<TMyParams>)
+  protected
+    function ExecuteWithParams(const AParams: TMyParams;
+      const AuthContext: TAiAuthContext): TJSONObject; override;
+  public
+    constructor Create; override;
+  end;
+
+// Registration
+AServer.RegisterTool('my_tool', function: IAiMCPTool begin Result := TMyTool.Create; end);
+```
+
+### Demo Tools
+
+| File | Tool | Purpose |
+|------|------|---------|
+| `uTool.FileAccess.pas` | list_files, read_file, write_file | File operations with path/extension whitelisting |
+| `uTool.SysInfo.pas` | system_info | System metrics (memory, disk, network) |
+| `uTool.WorldTime.pas` | get_city_time | Timezone lookups (placeholder for external API) |
+
+## Key Source Locations
+
+- Main entry: `AiMCPServerDemo.dpr`
+- Framework: `/Source/MCPServer/uMakerAi.MCPServer.Core.pas`
+- SSE transport: `/Source/MCPServer/UMakerAi.MCPServer.SSE.pas`
+- HTTP transport: `/Source/MCPServer/UMakerAi.MCPServer.Http.pas`
+- Stdio transport: `/Source/MCPServer/UMakerAi.MCPServer.Stdio.pas`
+
+## Testing Tools via HTTP
+
+```bash
+# List available tools
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+
+# Call a tool
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"system_info","arguments":{"type":"basic"}},"id":2}'
+```
+
+## Security Notes
+
+File access tools implement:
+- Path whitelist (temp dir, documents, app directory by default)
+- Extension whitelist (.txt, .json, .xml, .csv, .log, .md, .png, .jpg, .pdf, .docx, .xlsx, .mp3, .wav)
+- 10 MB file size limit for reads
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/032-MCPServerDataSnap/CLAUDE.md
+++ b/Demos/032-MCPServerDataSnap/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Delphi DataSnap REST server that implements the MCP (Model Context Protocol) for the MakerAi Delphi Suite. It exposes MCP tools via DataSnap REST methods using `TAiMCPDirectConnection` to map REST calls to internal MCP logic.
+
+## Build & Run
+
+- **IDE**: Embarcadero RAD Studio (Delphi)
+- **Project file**: `MCPDataSnapServer.dpr`
+- **Build**: Open project in RAD Studio and compile (Ctrl+F9) or build (F9)
+- **Output**: Console application (APPTYPE CONSOLE)
+- **Default port**: 8000
+
+### Console Commands
+```
+start       - Start the HTTP server
+stop        - Stop the server
+set port N  - Change port (e.g., "set port 9000")
+status      - Show server status
+help        - Show available commands
+exit        - Stop server and close application
+```
+
+## Architecture
+
+### Core Components
+
+```
+MCPDataSnapServer.dpr    → Main program, console UI, HTTP bridge (TIdHTTPWebBrokerBridge)
+    ↓
+uWebModule.pas           → Web module with TDSHTTPWebDispatcher for REST routing
+    ↓
+uServerContainer.pas     → DataSnap server container (TDSServer, TDSAuthenticationManager)
+    ↓
+uServerMethods.pas       → TSSE class: DataSnap server methods exposing MCP endpoints
+    ↓
+uTool.DataSnap.FileAccess.pas → MCP tool implementations with security config
+```
+
+### REST Endpoints
+
+Base URL: `http://localhost:8000/datasnap/rest/TSSE`
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/ListTools` | GET | Returns available MCP tools |
+| `/CallTool` | POST/GET | Executes a tool (params: ToolName, Args JSON) |
+| `/EchoString` | GET | Echo test |
+| `/ReverseString` | GET | String reversal test |
+
+### MCP Integration
+
+The `TSSE` data module uses `TAiMCPDirectConnection` (from MakerAi Suite) to:
+1. Register MCP tools with factory functions
+2. Handle tool listing and execution
+3. Manage per-session user context from DataSnap sessions
+
+### Security Model (TFileAccessConfig)
+
+File access tools enforce path and extension restrictions:
+- **Allowed paths**: Configured per-user in `TSSE.InitMCP`
+- **Allowed extensions**: .txt, .pdf, .json, .xml, .csv, .log, .md, .png, .jpg, .jpeg (configurable)
+- Tools: `list_files`, `read_file`, `write_file`
+
+Each tool inherits from `TAiFileToolBase<T>` which wraps `TFileAccessConfig` for security validation.
+
+## Dependencies
+
+External units from MakerAi Suite (not included in this project):
+- `uMakerAi.MCPServer.Core` - MCP protocol types, `TAiMCPServer`, `IAiMCPTool`
+- `uMakerAi.MCPServer.Direct` - `TAiMCPDirectConnection` for in-process MCP handling
+
+## Key Patterns
+
+- DataSnap uses `{$METHODINFO ON}` to expose public methods as REST endpoints
+- Tool parameters use RTTI attributes (`AiMCPSchemaDescription`, `AiMCPOptional`) for JSON schema generation
+- Authentication is configured but defaults to `valid := True` (TODO markers in code)
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/032-MCP_StdIO_FileManager/CLAUDE.md
+++ b/Demos/032-MCP_StdIO_FileManager/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Delphi demo project implementing MCP (Model Context Protocol) servers for file management operations. It's part of the MakerAI Suite and demonstrates three transport modes for MCP servers.
+
+## Architecture
+
+### Server Variants
+
+Three separate executables showcasing different MCP transport protocols:
+
+- **McpFileServerStIO.dpr** - Standard I/O transport (stdin/stdout). Primary mode for local AI tool integration (e.g., Claude Desktop).
+- **McpFileServerSSE.dpr** - Server-Sent Events over HTTP. Uses port 8080 with `/sse` and `/messages` endpoints.
+- **McpFileServerHttp.dpr** - Pure HTTP JSON-RPC. Uses port 8080 with `/mcp` endpoint.
+
+### Core Components
+
+All servers use the MakerAI MCP framework from `../../Source/MCPServer/`:
+
+- `uMakerAi.MCPServer.Core` - Base classes: `TAiMCPServer`, `TAiMCPToolBase<T>`, `IAiMCPTool`, `TAiMCPResponseBuilder`
+- `uMakerAi.MCPServer.Stdio` - `TAiMCPStdioServer` for stdin/stdout transport
+- `uMakerAi.MCPServer.SSE` - `TAiMCPSSEHttpServer` for SSE transport
+- `uMakerAi.MCPServer.Http` - `TAiMCPHttpServer` for HTTP transport
+
+### Tool Implementation Pattern
+
+Tools are implemented by:
+1. Defining a parameters class with `[AiMCPSchemaDescription]` attributes
+2. Creating a tool class inheriting from `TAiMCPToolBase<TParamsClass>`
+3. Implementing `ExecuteWithParams` returning `TJSONObject` via `TAiMCPResponseBuilder`
+4. Registering via `ALogicServer.RegisterTool('tool_name', function: IAiMCPTool begin Result := TMyTool.Create; end)`
+
+### Registered Tools
+
+**uTool.Sandbox.pas** - Sandboxed file operations (all paths relative to `SANDBOX_ROOT`):
+- `fs_list` - List directory contents
+- `fs_read` - Read file content
+- `fs_write` - Create/overwrite files
+- `fs_delete` - Delete files/directories
+- `fs_copy` - Copy files
+
+**uTool.WorldTime.pas**:
+- `get_city_time` - Get current time for a city (stub implementation)
+
+### Security
+
+All file operations are sandboxed to `SANDBOX_ROOT` (default: `d:\taller\mcpdir`). The `ResolvePath` function validates paths to prevent directory traversal attacks.
+
+## Build
+
+Open and compile in Delphi IDE using the `.dproj` project files. No external dependencies beyond standard Delphi RTL and the MakerAI framework.
+
+## Claude Desktop Configuration
+
+For StdIO mode (recommended):
+```json
+{
+  "mcpServers": {
+    "delphi-filemanager": {
+      "command": "path/to/McpFileServerStIO.exe",
+      "args": []
+    }
+  }
+}
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.
+```

--- a/Demos/035-MCPServerWithTAiFunctions/CLAUDE.md
+++ b/Demos/035-MCPServerWithTAiFunctions/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a **Delphi demo project** that demonstrates how to create an MCP (Model Context Protocol) Server using the **MakerAI Suite** framework. The server exposes TAiFunctions as MCP tools that can be called by AI clients.
+
+## Architecture
+
+The project uses the MakerAI MCP Server framework with three key components:
+
+- **TAiFunctions** (`AiFunctions1`): Component that defines callable functions/tools with parameters, descriptions, and action handlers
+- **TAiMCPHttpServer** (`AiMCPHttpServer1`): HTTP-based MCP server that listens on port 3000 with CORS enabled
+- **TAiMCPStdioServer** (`AiMCPStdioServer1`): Alternative StdIO-based MCP server (currently commented out)
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `MCPServerAiFunctions.dpr` | Main console application entry point |
+| `uMCPServerAiFunctionsDm.pas` | DataModule containing server components and function handlers |
+| `uMCPServerAiFunctionsDm.dfm` | Form file with component configurations |
+
+### MakerAI Framework Dependencies
+
+Located in the parent repository `Source/` folder:
+- `uMakerAi.MCPServer.Core` - Core MCP server logic and JSON-RPC handling
+- `uMakerAi.MCPServer.Bridge` - Proxy that converts TAiFunctions to IAiMCPTool interface
+- `UMakerAi.MCPServer.Http` - HTTP transport using Indy
+- `UMakerAi.MCPServer.Stdio` - StdIO transport for command-line integration
+
+## Build Commands
+
+```bash
+# Build using Delphi command-line compiler (requires RAD Studio installation)
+msbuild MCPServerAiFunctions.dproj /p:Config=Release /p:Platform=Win32
+
+# Or using dcc32/dcc64
+dcc64 MCPServerAiFunctions.dpr
+```
+
+## Server Configuration
+
+The HTTP server runs on:
+- **Port**: 3000 (configurable via `Port` property)
+- **Endpoint**: `/mcp`
+- **CORS**: Enabled with `*` origin allowed
+
+Settings can be loaded from an INI file (same name as executable with `.ini` extension).
+
+## Adding New Tools
+
+1. Add a new function item to `AiFunctions1.Functions` in the DFM or via code
+2. Define `FunctionName`, `Description`, and `Parameters` collection
+3. Implement the `OnAction` event handler:
+```pascal
+procedure TMyDataModule.OnMyFunctionAction(Sender: TObject;
+  FunctionAction: TFunctionActionItem; FunctionName: string;
+  ToolCall: TAiToolsFunction; var Handled: Boolean);
+begin
+  // Access parameters via ToolCall.Arguments (JSON string)
+  // Set response via ToolCall.Response
+  ToolCall.Response := 'Result here';
+  Handled := True;
+end;
+```
+
+## MCP Protocol
+
+The server implements JSON-RPC 2.0 with MCP methods:
+- `initialize` - Server capability handshake
+- `tools/list` - List available tools
+- `tools/call` - Execute a tool with arguments
+- `resources/list` / `resources/read` - Resource access (if configured)
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/036-MCPServerStdIO_AiFunction/CLAUDE.md
+++ b/Demos/036-MCPServerStdIO_AiFunction/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Delphi MCP (Model Context Protocol) Server that communicates via StdIO. It implements a file system tool that can be exposed to AI clients through the JSON-RPC protocol.
+
+## Build Commands
+
+Build using RAD Studio/Delphi IDE or MSBuild:
+```bash
+msbuild MCPServerFileSystem.dproj /p:Config=Debug /p:Platform=Win32
+```
+
+Output directory: `C:\mcp\servers\`
+
+## Architecture
+
+**Main Components:**
+
+- `MCPServerFileSystem.dpr` - Console application entry point. Creates the DataModule and starts the MCP StdIO server in an infinite loop.
+
+- `uMCPServerFileSystem_Tool.pas/.dfm` - TDataModule containing:
+  - `TAiMCPStdioServer` - MCP server component that handles JSON-RPC communication over StdIO
+  - `TAiFunctions` - Collection of AI-callable functions/tools
+
+**MakerAI Framework Dependencies:**
+- `uMakerAi.MCPServer.Core` - Core MCP server functionality
+- `uMakerAi.MCPServer.Bridge` - Bridge for MCP communication
+- `UMakerAi.MCPServer.Stdio` - StdIO transport implementation
+- `uMakerAi.Tools.Functions` - AI function/tool definitions
+- `uMakerAi.Core` / `uMakerAi.Chat.Messages` - Core AI types
+
+## Implementing New Tools
+
+1. Add a new function item to `AiFunctions1.Functions` collection in the DFM
+2. Set `FunctionName`, `Description`, and `Parameters`
+3. Create an `OnAction` event handler in the PAS file
+4. Access parameters via `ToolCall.Params.Values['param_name']`
+5. Set response via `ToolCall.Response := 'result'`
+6. Set `Handled := True` to indicate completion
+
+## Current Tools
+
+- `fs_listar` - Lists files in a sandbox directory with optional filter parameter
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/041-GeminiVeo/CLAUDE.md
+++ b/Demos/041-GeminiVeo/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is **VeoDemo**, a Delphi FireMonkey (FMX) demo application for Google's Gemini Veo video generation API. It's part of the MakerAI Suite - an AI orchestration framework for Delphi.
+
+## Build Commands
+
+Open `VeoDemo.dproj` in Delphi IDE (11 Alexandria to 13 Florence) and build. No command-line build configured.
+
+Requires MakerAI library units in the Delphi Library Path:
+- `uMakerAi.Gemini.Veo` - Veo API wrapper
+- `uMakerAi.UI.ChatInput` / `uMakerAi.UI.ChatList` - FMX chat components
+- `uMakerAi.Core` - Core types (`TAiMediaFile`, `TAiMediaFiles`, `TAiFileCategory`)
+- `uMakerAi.utils.System` - Utility functions
+
+## Architecture
+
+### Main Components
+
+- **`TAiVeoGenerator`** (`AiVeo`): Non-visual component wrapping Gemini Veo API. Configured via properties: `Model`, `AspectRatio`, `Resolution`, `PersonGeneration`, `DurationSeconds`, `NegativePrompt`. API key set via `@GEMINI_API_KEY` placeholder.
+
+- **`TChatInput`** / **`TChatList`**: MakerAI FMX components for user input with file attachments and message history display.
+
+### Video Generation Modes
+
+The app auto-selects generation mode based on attached files:
+
+| Attachments | Mode |
+|-------------|------|
+| None | Text-to-Video (`GenerateFromText`) |
+| 1 image | Image-to-Video (`GenerateFromImage`) |
+| 1 video | Extend Video (`ExtendVideo`) - requires `.veometa` file |
+| 2 images | Interpolation (`GenerateFromFrames`) or Reference mode |
+| 3 images | Reference Images (`GenerateWithReferences`) |
+
+User can force mode via radio buttons when 2 images attached.
+
+### Key Types
+
+```pascal
+TVeoGenerationMode = (gmAuto, gmFrames, gmReferences);
+TVeoModel = (vmCustom, vmVeo3_1, vmVeo3_1_Fast, vmVeo3_0, vmVeo3_0_Fast, vmVeo2_0);
+TVeoAspectRatio = (arDefault, ar16x9, ar9x16);
+TVeoResolution = (vrDefault, vr720p, vr1080p);
+TVeoPersonGeneration = (pgDefault, pgAllowAll, pgAllowAdult, pgDontAllow);
+```
+
+### Event Flow
+
+1. `ChatInput1SendEvent` → collects prompt, media files, and configuration
+2. `ExecuteVeoTask` → routes to appropriate `AiVeo` method based on attachments
+3. `AiVeoProgress` → updates status in log
+4. `AiVeoSuccess` → displays result, prompts to save `.mp4` and `.veometa`
+5. `AiVeoError` → displays error message
+
+### Video Extension Workflow
+
+Generated videos can be extended if saved with metadata:
+- Video saved as `.mp4`
+- Metadata saved as `.veometa` (JSON without base64 content, contains `UrlMedia` identifier)
+- To extend: attach the `.mp4` file (must have adjacent `.veometa`)
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/051-AgentDemo/CLAUDE.md
+++ b/Demos/051-AgentDemo/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Delphi FMX demo application showcasing the **MakerAI Agents Framework** (`uMakerAi.Agents`). It demonstrates building AI agent workflows using visual graph-based components.
+
+## Build Commands
+
+```bash
+# Compile with Delphi command-line compiler (Windows)
+DCC64 AiAgentDemo.dpr
+
+# Or use MSBuild
+msbuild AiAgentDemo.dproj /p:Config=Release /p:Platform=Win64
+```
+
+## Architecture
+
+### MakerAI Agents Framework Components
+
+The demo uses three core visual components from `uMakerAi.Agents`:
+
+- **TAIAgentManager** (`TAIAgents`): Orchestrates agent graph execution. Configured with `StartNode`, `EndNode`, `TimeoutMs`, and events (`OnPrint`, `OnFinish`).
+
+- **TAIAgentsNode**: Individual processing unit in the graph. Each node has:
+  - `OnExecute` handler receiving `(Node, BeforeNode, Link, Input, Output)`
+  - `Next` property pointing to a `TAIAgentsLink`
+  - `JoinMode` (jmAny/jmAll) for parallel branch convergence
+  - `Print()` method for logging
+
+- **TAIAgentsLink**: Edges connecting nodes with routing logic:
+  - `NextA`, `NextB`, `NextC`, `NextD`: Target nodes
+  - `NextNo`: Fallback when condition fails
+  - `Mode`: lmFanout (parallel), lmConditional, lmManual, lmExpression
+  - `OnExecute` handler returns `IsOk` to control routing
+
+### Graph Patterns Demonstrated
+
+1. **Sequential Flow**: `AIGraph1` - StartNode → AiNode → ExecuteNode → EvalNode → EndNode
+   - Generates Delphi console code via AI
+   - Compiles with DCC64
+   - Evaluates compilation result
+   - Loops back to AiNode on error (Link4.NextNo)
+
+2. **Parallel Fan-out**: `AIAgentsManager` - NodoInicio → (TareaA || TareaB) → NodoFinal
+   - Uses `AIAgentsLink1` with both NextA and NextB set
+   - NodoFinal has `JoinMode = jmAll` to wait for both branches
+
+### Key Integration Points
+
+- **TAiOpenChat**: OpenAI chat component for AI interactions
+- **TAiPrompts**: Template-based prompt management with variable substitution (`GetTemplate('name', ['var=value'])`)
+- **TUtilsSystem**: System utilities for command execution (`RunCommandLine`, `ExecuteCommandLine`)
+
+### Thread Safety
+
+All UI updates from node handlers use `TThread.Synchronize` since agent execution runs asynchronously.
+
+## Dependencies
+
+Part of the MakerAI Suite. Requires:
+- Source/Core units (`uMakerAi.Core`, `uMakerAi.Chat`, etc.)
+- Source/Agents units
+- Delphi 11 Alexandria or later
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/052-AgentConsole/CLAUDE.md
+++ b/Demos/052-AgentConsole/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a console demo application for the **MakerAI Agents** framework, showcasing graph-based AI agent orchestration in Delphi. The demo demonstrates two flow patterns:
+1. **Conditional Flow (IF/ELSE)**: Branching execution based on decisions stored in the Blackboard
+2. **Parallel Flow (Fork/Join)**: Concurrent task execution with synchronization
+
+## Build Commands
+
+Build using Delphi's MSBuild from the command line:
+
+```bash
+# Debug build (Win32)
+msbuild AgentConsoleDemo.dproj /p:Config=Debug /p:Platform=Win32
+
+# Debug build (Win64)
+msbuild AgentConsoleDemo.dproj /p:Config=Debug /p:Platform=Win64
+
+# Release build
+msbuild AgentConsoleDemo.dproj /p:Config=Release /p:Platform=Win64
+```
+
+Output binaries are placed in `.\$(Platform)\$(Config)\` (e.g., `.\Win64\Debug\AgentConsoleDemo.exe`).
+
+## Architecture
+
+### Core Components (from `uMakerAi.Agents`)
+
+- **`TAIAgentManager`** (alias `TAIAgents`): The graph orchestrator managing nodes, links, and execution. Key methods:
+  - `AddNode(Name, ExecuteProc)`: Adds a node with an execution callback
+  - `AddEdge(Start, End)`: Creates a simple edge between nodes
+  - `AddConditionalEdge(Start, LinkName, Conditions)`: Creates conditional routing
+  - `SetEntryPoint(Name)` / `SetFinishPoint(Name)`: Defines flow endpoints
+  - `Run(Input)`: Executes the graph
+
+- **`TAIAgentsNode`**: Execution unit with:
+  - `OnExecute` callback: `(Node, BeforeNode, Link, Input, var Output)`
+  - `JoinMode`: `jmAny` (first input) or `jmAll` (wait for all parallel branches)
+  - `Next`: Link to subsequent node(s)
+
+- **`TAIAgentsLink`**: Edge connecting nodes. Supports:
+  - `lmFanout`: Parallel execution (NextA, NextB, NextC, NextD)
+  - `lmConditional`: Routes based on Blackboard key
+  - `lmExpression`: Routes based on expression evaluation
+
+- **`TAIBlackboard`**: Thread-safe shared state dictionary. Use `SetString(key, value)` and `GetString(key)` for conditional routing.
+
+### Demo Flow Patterns
+
+**Conditional Flow** (lines 196-249):
+```
+Start -> Work -> Decide --(ok)--> OkNode --\
+                        \--(fail)--> FailNode --> Finish
+```
+Decision uses `Blackboard.SetString('next_route', decision)`.
+
+**Parallel Flow** (lines 252-318):
+```
+Start --ForkLink--> TaskA --JoinLinkA--\
+                \-> TaskB --JoinLinkB--> JoinNode (jmAll)
+```
+Manual link creation for fork/join patterns.
+
+### Key Events
+
+- `OnPrint`: Log output during execution
+- `OnEnd`: Called when finish node completes
+- `OnError`: Exception handling with abort option
+- `OnConfirm`: User confirmation dialogs
+
+### Threading Model
+
+- Graph execution runs asynchronously via `TTask`
+- Use `CheckSynchronize` in console apps for `TThread.Synchronize` calls
+- `Busy` property indicates active execution
+
+## Dependencies
+
+Requires the MakerAI framework. Add these paths to Library Path:
+- `../../Source/Agents`
+- `../../Source/Chat`
+- `../../Source/Core`
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/053-DemoAgentesTools/CLAUDE.md
+++ b/Demos/053-DemoAgentesTools/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Delphi FMX demo application showcasing AI agent tools integration using the MakerAI library. It demonstrates multiple AI provider integrations and RAG (Retrieval Augmented Generation) capabilities.
+
+## Build Commands
+
+- Open `DemoAgentesTools.dproj` in Delphi IDE (RAD Studio)
+- Build with `Shift+F9` or Run with `F9`
+- Command line: `msbuild DemoAgentesTools.dproj` (requires RAD Studio command prompt)
+
+## Architecture
+
+### Main Components
+
+- **DemoAgentesTools.dpr** - Application entry point
+- **uMainDemoAgenteTools.pas** - Main form with UI (FMX)
+- **uDmAgentesTool.pas** - Data module containing all AI service components
+
+### AI Provider Integration
+
+The data module (`TFDataModule`) integrates multiple AI services through MakerAI components:
+
+| Component | Provider | Purpose |
+|-----------|----------|---------|
+| `AiGeminiChat1` | Google Gemini | Web search with Gemini 3 Pro |
+| `AiOpenChat1` | OpenAI | Chat with GPT-5, web search enabled |
+| `NanoBanana` | Google Gemini | Image generation (gemini-3-pro-image-preview) |
+| `OllamaHtml` | Ollama (local) | HTML/Dashboard generation (gpt-oss:20b) |
+| `AiOllamaEmbeddings1` | Ollama (local) | Embeddings (snowflake-arctic-embed, 1024 dims) |
+| `AiOllamaPdfTool1` | Ollama (local) | PDF to text extraction (deepseek-ocr) |
+
+### RAG System
+
+- **TAiRAGVector** - Vector store manager with BM25/embedding hybrid search
+- **TAiRAGVectorPostgresDriver** - PostgreSQL pgvector backend
+- **VQL Support** - Vector Query Language via `ExecuteVGQL()`
+
+### Key Methods in TFDataModule
+
+- `WebSearch(Pregunta)` - AI-powered web search via OpenAI
+- `BuscarRAGV(Pregunta)` - Semantic vector search (top 10, threshold 0.7)
+- `BuscarVQL(Pregunta)` - Execute VQL queries
+- `CreateImage(Pregunta)` - Generate images via Gemini
+- `CreateDashBoard(Pregunta)` - Generate HTML dashboards via local Ollama
+- `PdfToText(FileName)` - Extract text from PDFs using OCR
+
+## External Dependencies
+
+- PostgreSQL database (`lunaidb`) with pgvector extension
+- Ollama running locally on port 11434
+- Ghostscript (`gswin64c.exe`) for PDF processing
+
+## API Keys Configuration
+
+Keys are configured in the DFM using environment variable syntax:
+- `@GEMINI_API_KEY`
+- `@OPENAI_API_KEY`
+- `@OLLAMA_API_KEY`
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/090-Varios/CLAUDE.md
+++ b/Demos/090-Varios/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This folder contains miscellaneous MakerAI demo applications demonstrating various library features.
+
+## Build Commands
+
+```bash
+# Build console app
+msbuild ListAllModels.dproj /p:Config=Debug /p:Platform=Win32
+
+# Build VCL app
+msbuild CompareEmbeddings/CompareEmbeddings.dproj /p:Config=Debug /p:Platform=Win32
+```
+
+Or open `../../DemosVersion31.groupproj` in RAD Studio IDE.
+
+## Demo Projects
+
+### ListAllModels (Console)
+Lists all registered LLM drivers and their available models using `TAiChatConnection`. Demonstrates:
+- Driver registration system via `uMakerAi.chat.Initializations`
+- `TAiChatConnection.GetDriversNames` / `GetModels` API
+
+### CompareEmbeddings (VCL)
+Compares text similarity using Ollama embeddings. Requires Ollama running locally.
+- Uses `TAiOllamaEmbeddings.CreateEmbedding()` to generate vectors
+- Compares via `CosineSimilarity()` and `EuclideanDistance()`
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for demos overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Demos/090-Varios/CompareEmbeddings/CLAUDE.md
+++ b/Demos/090-Varios/CompareEmbeddings/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Delphi VCL demo application that compares text embeddings using the MakerAI library. It demonstrates similarity calculations between two text inputs using Ollama embeddings.
+
+## Build Commands
+
+```bash
+# Build from command line using MSBuild (requires RAD Studio installed)
+msbuild CompareEmbeddings.dproj /p:Config=Debug /p:Platform=Win32
+msbuild CompareEmbeddings.dproj /p:Config=Release /p:Platform=Win64
+```
+
+Alternatively, open `CompareEmbeddings.dproj` in RAD Studio IDE and build with F9.
+
+## Architecture
+
+**Main Form**: `uMainCompareEmbeddings.pas` (TForm14)
+- Uses `TAiOllamaEmbeddings` component from MakerAI library to generate embeddings via Ollama
+- Compares two text inputs using:
+  - **Cosine Similarity**: Measures angle between embedding vectors (higher = more similar)
+  - **Euclidean Distance**: Measures absolute distance (lower = more similar)
+
+## Dependencies
+
+- **MakerAI library**: Provides `uMakerAi.Embeddings.core`, `uMakerAi.Embeddings`, and `uMakerAi.Chat.Ollama` units
+- **Ollama**: Must be running locally for embeddings generation
+
+## Key Components
+
+- `TAiOllamaEmbeddings`: Generates embeddings via local Ollama instance
+- `TAiEmbeddingData`: Data structure holding embedding vectors
+- `CosineSimilarity()` / `EuclideanDistance()`: Comparison methods
+
+## Navigation
+
+> See [../../CLAUDE.md](../../CLAUDE.md) for demos overview and [../../../CLAUDE.md](../../../CLAUDE.md) for project overview.

--- a/Demos/CLAUDE.md
+++ b/Demos/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is the Demos directory for the MakerAI 3.x framework. Contains 18+ working example applications demonstrating AI integration patterns for Delphi developers. Each demo has its own CLAUDE.md with specific implementation details.
+
+## Building Demos
+
+**IDE:** Delphi 11 Alexandria through 13 Florence (demos require Delphi 11+; the core framework supports 10.4 Sydney minimum)
+
+**Group project:** Open `DemosVersion31.groupproj` in Delphi IDE to access all demos.
+
+**Individual build (MSBuild):**
+```bash
+msbuild 010-Minimalchat/MinimalChat.dproj /p:Config=Release /p:Platform=Win64
+```
+
+**Build all demos:**
+```bash
+msbuild DemosVersion31.groupproj /t:Build /p:Config=Release /p:Platform=Win64
+```
+
+**Output:** Each project compiles to `./$(Platform)/$(Config)/` (e.g., `./Win64/Release/`)
+
+## Demo Categories
+
+### Chat Integration (01x)
+| Demo | Purpose | Key Pattern |
+|------|---------|-------------|
+| 010-Minimalchat | Basic FMX chat | `TAiOllamaChat` direct + `TAiChatConnection` factory |
+| 012-ChatAllFunctions | Full-featured chat | Multimodal (images, audio), streaming, tool calls |
+| 014-ChatTest | Claude-specific testing | Claude API integration |
+
+### RAG Systems (02x)
+| Demo | Purpose | Key Classes |
+|------|---------|-------------|
+| 021-RAG+Postgres-UpdateDB | Vector RAG with PostgreSQL | `TAiVectorRAG`, pgvector |
+| 022-1-RAG_SQLite | Vector RAG with SQLite | Lightweight local storage |
+| 023-RAGVQL | Vector Query Language | VQL semantic search syntax |
+| 025-RAGGraph | Knowledge graph RAG | `TAiGraphRAG`, entity relationships |
+| 026-RAGGraph-Basic | Basic graph RAG | Simplified graph patterns |
+
+### MCP Servers (03x)
+| Demo | Purpose | Transport |
+|------|---------|-----------|
+| 031-MCPServer | Multi-protocol server | SSE, HTTP, StdIO |
+| 032-MCP_StdIO_FileManager | File manager MCP | StdIO, HTTP, SSE variants |
+| 032-MCPServerDataSnap | DataSnap integration | HTTP with DataSnap |
+| 035-MCPServerWithTAiFunctions | MCP + function calling | TAiFunctions integration |
+| 036-MCPServerStdIO_AiFunction | Function-based MCP | StdIO with AI functions |
+
+### Video Generation (04x)
+| Demo | Purpose | Provider |
+|------|---------|----------|
+| 041-GeminiVeo | Video generation | Google Veo API |
+
+### Agent Orchestration (05x)
+| Demo | Purpose | Key Pattern |
+|------|---------|-------------|
+| 051-AgentDemo | Agent graph workflows | `TAIAgentManager`, visual orchestration |
+| 052-AgentConsole | Console agent interface | Command-line agent execution |
+| 053-DemoAgentesTools | Agents with tools | Tool integration in agent flows |
+
+### Utilities (09x)
+| Demo | Purpose |
+|------|---------|
+| 090-Varios/ListAllModels | List available models across providers |
+| 090-Varios/CompareEmbeddings | Compare embedding quality |
+
+## Common Runtime Dependencies
+
+- **Ollama**: Required for local models (default: `localhost:11434`)
+- **API Keys**: OpenAI, Claude, Gemini keys in environment or config
+- **PostgreSQL + pgvector**: For 021-RAG demos
+- **SQLite**: For 022-RAG demos (included with Delphi)
+
+## Navigation Pattern
+
+Each demo subdirectory contains:
+- `*.dproj` - Delphi project file
+- `*.dpr` - Program source
+- `uMain*.pas` / `uMain*.fmx` - Main form
+- `CLAUDE.md` - Demo-specific instructions
+
+## Common Code Patterns Across Demos
+
+**Synchronous AI call:**
+```pascal
+AiModel.Asynchronous := False;
+Response := AiModel.AddMessageAndRun(Prompt, 'user', []);
+```
+
+**Streaming with callback:**
+```pascal
+AiModel.Asynchronous := True;
+AiModel.OnReceiveData := procedure(Sender: TObject; Data: string; IsDone: Boolean)
+begin
+  TThread.Synchronize(nil, procedure begin Memo1.Text := Memo1.Text + Data; end);
+end;
+AiModel.AddMessageAndRun(Prompt, 'user', []);
+```
+
+**Error handling:**
+```pascal
+AiModel.OnError := procedure(Sender: TObject; ErrorMsg: string; E: Exception; Resp: IHTTPResponse)
+begin
+  ShowMessage(ErrorMsg);
+end;
+```
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for project overview, build instructions, and architecture details.

--- a/Docs/CLAUDE.md
+++ b/Docs/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Directory Purpose
+
+This is the documentation root for MakerAI v3.2 - an AI orchestration framework for Delphi. **No source code exists here** - all implementation is in `/Source/`.
+
+## Documentation Structure
+
+```text
+Docs/
+└── Version 3/           ← Current version documentation
+    ├── Agents/          ← Agent orchestration (graph-based workflows)
+    ├── MCPServer/       ← Model Context Protocol server implementation
+    ├── RAG/             ← Retrieval-Augmented Generation (vector + graph)
+    └── PDF/             ← Distribution-ready consolidated PDFs
+```
+
+## Language
+
+Documentation is primarily in **Spanish**. English versions available for:
+- MCP Server (`MCPServer/uMakerAi-MCP.Server.EN.pdf`)
+
+## Subdirectory CLAUDE.md Files
+
+Specialized guidance exists in subdirectories:
+- `Version 3/CLAUDE.md` - Full documentation map and source code cross-references
+- `Version 3/MCPServer/CLAUDE.md` - MCP protocol patterns, testing commands
+- `Version 3/RAG/CLAUDE.md` - pgvector reference, RAG implementation patterns
+
+## Key Documentation → Source Mapping
+
+| Documentation | Source Code |
+|---------------|-------------|
+| `uMakerAi-ChatConnection.docx` | `Source/Chat/uMakerAi.Chat.AiConnection.pas` |
+| `uMakerAi.Chat.docx` | `Source/Core/uMakerAi.Chat.pas` |
+| `uMakerAi-Agents.ES.docx` | `Source/Agents/uMakerAi.Agents.pas` |
+| `uMakerAi-RAG.ES.docx` | `Source/RAG/uMakerAi.RAG.Vectors.pas` |
+| `uMakerAI-RAGGraph.docx` | `Source/RAG/uMakerAi.RAG.Graph.Core.pas` |
+| `uMakerAi-MCP.Server.*.docx` | `Source/MCPServer/uMakerAi.MCPServer.Core.pas` |
+| `uMakerAi.ToolFuncions.docx` | `Source/Tools/uMakerAi.Tools.Functions.pas` |
+
+## File Formats
+
+- `.docx` - Editable source documents (Word)
+- `.pdf` - Distribution versions
+- `.xlsx` - Test specification matrix (`Test List.xlsx`)
+- `.m4a` - Webinar audio recordings
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for project overview.

--- a/Docs/Version 3/CLAUDE.md
+++ b/Docs/Version 3/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Directory Purpose
+
+This directory contains technical documentation for MakerAI v3.2 - an AI orchestration framework for Delphi. The documentation is primarily in Spanish with English versions available for key modules.
+
+**This is documentation only** - no source code lives here. Source code is in `/Source/`.
+
+## Documentation Structure
+
+| Directory | Content | Language |
+|-----------|---------|----------|
+| Root | Installation guide, component user guides, chat/prompts/tools docs | Spanish |
+| `Agents/` | Agent orchestration guide, conditional language appendix, webinar audio | Spanish |
+| `MCPServer/` | MCP Server technical documentation | English + Spanish |
+| `RAG/` | Vector and knowledge graph RAG documentation | Spanish |
+| `PDF/` | Consolidated PDF versions for distribution | Both |
+
+## Subdirectory CLAUDE.md Files
+
+Two subdirectories have specialized guides:
+- `MCPServer/CLAUDE.md` - MCP protocol implementation patterns, testing commands
+- `RAG/CLAUDE.md` - pgvector reference, RAG implementation patterns
+
+## Key Documentation Files
+
+| File | Covers |
+|------|--------|
+| `Manual Instalacion.docx` | Step-by-step installation |
+| `uMakerAi-ChatConnection.docx` | Universal LLM connector (`TAiChatConnection`) |
+| `uMakerAi.Chat.docx` | Chat message handling and state machine |
+| `uMakerAi-Agents.ES.docx` | Graph-based agent orchestration |
+| `uMakerAi-RAG.ES.docx` | Vector RAG with PostgreSQL/pgvector |
+| `uMakerAI-RAGGraph.docx` | Knowledge graph RAG |
+| `uMakerAi.ToolFunciones.docx` | Function calling system |
+| `TAiChatClaude-Guia de Uso.docx` | Claude provider specifics |
+| `TAiChatGemini-Guia de Uso.docx` | Gemini provider specifics |
+
+## Cross-Reference to Source Code
+
+Documentation files map to source directories:
+
+| Documentation | Source Location |
+|---------------|-----------------|
+| Chat/ChatConnection docs | `Source/Chat/`, `Source/Core/` |
+| Agent docs | `Source/Agents/uMakerAi.Agents.pas` |
+| RAG docs | `Source/RAG/` |
+| MCP Server docs | `Source/MCPServer/` |
+| Tools/Functions docs | `Source/Tools/uMakerAi.Tools.Functions.pas` |
+
+## File Formats
+
+- `.docx` - Editable source documents
+- `.pdf` - Distribution-ready versions
+- `.xlsx` - Test specification matrix (`Test List.xlsx`)
+- `.m4a` - Webinar audio (Agents orchestration)
+
+## Translation Notes
+
+Most documentation is Spanish-first. English versions exist for:
+- MCP Server (`uMakerAi-MCP.Server.EN.docx/.pdf`)
+
+When referencing documentation for English speakers, prefer the MCPServer English docs or the parent project's `CLAUDE.md` which is in English.
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for documentation index and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Docs/Version 3/MCPServer/CLAUDE.md
+++ b/Docs/Version 3/MCPServer/CLAUDE.md
@@ -1,0 +1,128 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This directory contains documentation for the **MakerAI MCP Server** module - a Model Context Protocol implementation for Delphi that allows applications to expose AI-callable tools and resources through standardized protocols (HTTP, SSE, StdIO, Direct).
+
+## Source Code Location
+
+The MCPServer source code is located in `/Source/MCPServer/` (6 units, ~2,900 lines):
+
+| Unit | Purpose |
+|------|---------|
+| `uMakerAi.MCPServer.Core.pas` | Core classes, interfaces, JSON-RPC engine, tool/resource registry |
+| `UMakerAi.MCPServer.Http.pas` | Stateless HTTP JSON-RPC transport |
+| `UMakerAi.MCPServer.SSE.pas` | Server-Sent Events transport (bidirectional, session-aware) |
+| `UMakerAi.MCPServer.Stdio.pas` | Standard I/O transport for subprocess integration |
+| `UMakerAi.MCPServer.Direct.pas` | In-process direct invocation (zero network overhead) |
+| `uMakerAi.MCPServer.Bridge.pas` | Adapter bridging TAiFunctions to IAiMCPTool interface |
+
+## Building
+
+MCPServer is included in the main MakerAI runtime package. Compile from Delphi IDE:
+
+```
+Open: Source/Packages/MakerAI.dpk
+Build → Compile
+```
+
+Required library paths: `Source/MCPServer`, `Source/Core`, `Source/Tools`, `Source/Utils`
+
+## Demo Projects
+
+Located in `/Demos/`:
+
+| Demo | Description | Command |
+|------|-------------|---------|
+| `031-MCPServer` | Multi-protocol showcase | `AiMCPServerDemo.exe --protocol {sse\|http\|stdio} --port 8080` |
+| `032-MCPServerDataSnap` | DataSnap integration | |
+| `035-MCPServerWithTAiFunctions` | TAiFunctions integration | HTTP on port 3000 |
+| `036-MCPServerStdIO_AiFunction` | StdIO + functions | |
+
+## Testing the Server
+
+```bash
+# List tools
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+
+# Call a tool
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"system_info","arguments":{"type":"basic"}},"id":2}'
+```
+
+## Architecture
+
+### Class Hierarchy
+
+```
+TAiMCPLogicServer (JSON-RPC engine, tool/resource registry)
+    └── TAiMCPServer (TComponent wrapper)
+            ├── TAiMCPHttpServer
+            ├── TAiMCPSSEHttpServer
+            ├── TAiMCPStdioServer
+            └── TAiMCPDirectConnection
+```
+
+### Key Interfaces
+
+- `IAiMCPTool` - Tool contract: `GetName`, `GetDescription`, `GetInputSchema`, `Execute`
+- `IAiMCPResource` - Resource contract: `GetURI`, `GetName`, `Read`
+
+### Tool Implementation Pattern
+
+```delphi
+type
+  TMyParams = class
+    [AiMCPSchemaDescription('File path to process')]
+    property Path: string read FPath write FPath;
+  end;
+
+  TMyTool = class(TAiMCPToolBase<TMyParams>)
+  protected
+    function ExecuteWithParams(const AParams: TMyParams;
+      const AuthContext: TAiAuthContext): TJSONObject; override;
+  public
+    constructor Create; override;
+  end;
+
+// Registration
+Server.RegisterTool('my_tool',
+  function: IAiMCPTool begin Result := TMyTool.Create; end);
+```
+
+### Schema Attributes
+
+- `[AiMCPSchemaDescription('...')]` - Parameter description
+- `[AiMCPOptional]` - Mark parameter as optional
+- `[AiMCPSchemaEnum(['a', 'b'])]` - Enum constraint
+
+### MCP Protocol Methods
+
+| Method | Purpose |
+|--------|---------|
+| `initialize` | Server capability handshake |
+| `tools/list` | List available tools |
+| `tools/call` | Execute tool with arguments |
+| `resources/list` | List available resources |
+| `resources/read` | Read resource content |
+
+## Protocol Selection Guide
+
+- **HTTP**: Simple clients, stateless interactions, load balancing
+- **SSE**: Claude Desktop, MakerAI clients, real-time streaming
+- **StdIO**: Local subprocess, CLI integration
+- **Direct**: Embedded integration, testing, same-process calls
+
+## Documentation Files
+
+- `uMakerAi-MCP.Server.EN.pdf` - English technical documentation
+- `uMakerAi-MCP.Server.ES.pdf` - Spanish technical documentation
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for Version 3 documentation index and [../../../CLAUDE.md](../../../CLAUDE.md) for project overview.

--- a/Docs/Version 3/RAG/CLAUDE.md
+++ b/Docs/Version 3/RAG/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Folder Purpose
+
+This folder contains Spanish-language documentation for the MakerAI RAG (Retrieval-Augmented Generation) module. The documentation covers both theoretical concepts and practical implementation with the MakerAi Delphi Suite.
+
+## Documentation Files
+
+- `uMakerAi-RAG.ES.pdf` / `.docx` - Comprehensive RAG manual covering:
+  - RAG fundamentals and architecture (indexing, chunking, embeddings, vector stores)
+  - Hands-on tutorial using `TAiRAGVector` with PostgreSQL/pgvector
+  - Optimization techniques (chunking strategies, query transformation, re-ranking, self-correction)
+  - Structured RAG with knowledge graphs vs vector RAG
+  - Multimodal RAG considerations
+  - Evaluation metrics (Faithfulness, Answer Relevancy, Context Precision/Recall)
+  - Production deployment considerations
+
+- `uMakerAi-Agents.ES.docx` - Agent orchestration documentation
+
+## Key MakerAI RAG Components (from documentation)
+
+| Component | Purpose |
+|-----------|---------|
+| `TAiRAGVector` | Core RAG orchestrator for indexing and search |
+| `TAiOllamaEmbeddings` / `TAiOpenAiEmbeddings` | Embedding generation |
+| `TAIAgents` | Agent workflow orchestration for advanced RAG patterns |
+| `TAiEmbeddingNode` | Vector representation with `CosineSimilarity` method |
+
+## RAG Implementation Pattern (PostgreSQL/pgvector)
+
+```pascal
+// Indexing: AddItemsFromPlainText triggers OnDataVecAddItem event
+RAGVector.AddItemsFromPlainText(TextoCompleto, 512, 80); // chunk_size, overlap
+
+// Search: SearchText triggers OnDataVecSearch event
+ContextoRecuperado := RAGVector.SearchText(Pregunta, 5, 0.0); // limit, precision
+```
+
+Events `OnDataVecAddItem` and `OnDataVecSearch` handle database persistence with pgvector's `<->` operator for cosine distance.
+
+## pgvector Quick Reference
+
+```sql
+-- Enable extension
+CREATE EXTENSION vector;
+
+-- Create table with vector column
+CREATE TABLE items (embedding vector(1024));
+
+-- Cosine distance search
+SELECT * FROM items ORDER BY embedding <-> :query_embedding LIMIT 5;
+
+-- Create HNSW index (recommended)
+CREATE INDEX ON items USING hnsw (embedding vector_cosine_ops);
+```
+
+## Related Source Code
+
+The implementation code for these components is in the parent project:
+- `Source/RAG/uMakerAi.RAG.Vectors.pas` - Vector RAG implementation
+- `Source/RAG/uMakerAi.RAG.Graph.Core.pas` - Knowledge graph RAG
+- `Source/Core/uMakerAi.Embeddings.pas` - Embedding generation
+- `Source/Agents/uMakerAi.Agents.pas` - Agent orchestration
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for Version 3 documentation index and [../../../CLAUDE.md](../../../CLAUDE.md) for project overview.

--- a/Redis/CLAUDE.md
+++ b/Redis/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Directory Purpose
+
+This `Redis/` directory contains binary dependencies (audio conversion DLLs) for the MakerAI framework. It does not contain source code.
+
+**Contents:**
+- `ConvertToWave32.dll` - 32-bit audio format conversion
+- `ConvertToWave64.dll` - 64-bit audio format conversion
+
+These DLLs are used by MakerAI's voice processing components (`uMakerAi.Utils.VoiceMonitor.pas`, Whisper integration).
+
+## Main Project Documentation
+
+For MakerAI development guidance, see the parent directory's documentation:
+- `../CLAUDE.md` - Main Claude Code instructions
+- `../Readme.md` - Project overview and installation guide
+- `../Docs/` - Detailed architecture and API documentation

--- a/Resources/CLAUDE.md
+++ b/Resources/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Directory Purpose
+
+This `Resources/` directory contains visual assets (icons, logos) used by the MakerAI framework's design-time components and demo applications. These are compiled into `.res` files for the Delphi packages.
+
+## Main Project Documentation
+
+See the root `/CLAUDE.md` for complete project documentation including:
+- Build and installation instructions
+- Architecture overview
+- Package compilation order
+- Library path configuration
+
+## Asset Files
+
+| File | Purpose |
+|------|---------|
+| `Logo*.png/bmp/cdr` | MakerAI branding assets |
+| `*_48px.png`, `*_50px.png` | UI icons for toolbars and dialogs |
+
+## Related Source
+
+The resource compilation unit is at `Source/Resources/UIResources.res`.

--- a/Source/Agents/CLAUDE.md
+++ b/Source/Agents/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Module Overview
+
+The Agents module implements a graph-based autonomous agent orchestration framework. It enables building workflows where multiple AI-powered nodes execute in sequence or parallel, with conditional routing and shared state management.
+
+## Unit Structure
+
+| Unit | Purpose |
+|------|---------|
+| `uMakerAi.Agents.pas` | Core framework: `TAIAgentManager`, `TAIAgentsNode`, `TAIAgentsLink`, `TAIBlackboard` |
+| `uMakerAi.Agents.Attributes.pas` | RTTI attributes `TToolAttribute` and `TToolParameterAttribute` for tool metadata |
+| `uMakerAi.Agents.EngineRegistry.pas` | Singleton registries for tool discovery (`TEngineRegistry`, `TAgentHandlerRegistry`) |
+| `uMakerAi.Agents.GraphBuilder.pas` | `TGraphBuilder` parses JSON graph specs into runtime structures |
+| `uMakerAi.Agents.DmGenerator.pas` | `TDataModuleGenerator` generates Delphi DataModule code from JSON graphs |
+
+## Core Classes
+
+**TAIAgentManager** - Orchestrates workflow execution via TThreadPool. Key properties: `StartNode`, `EndNode`, `MaxConcurrentTasks` (default 4). Use `Run(APrompt)` for sync execution, `Compile()` to validate before running.
+
+**TAIAgentsNode** - Workflow vertex. Executes via `OnExecute` callback or attached `Tool: TAiToolBase`. Join modes: `jmAny` (first input triggers), `jmAll` (waits for all inputs).
+
+**TAIAgentsLink** - Directed edge connecting nodes. Four routing modes:
+- `lmFanout` - Broadcasts to all NextA/B/C/D slots
+- `lmConditional` - Routes based on `Blackboard[ConditionalKey]` value
+- `lmManual` - Targets specified programmatically via `ManualTargetsKey`
+- `lmExpression` - Evaluates `ExpressionA/B/C/D` bindings against blackboard
+
+**TAIBlackboard** - Thread-safe shared state (TDictionary with TCriticalSection). Standard accessors: `SetString/GetString`, `SetInteger/GetInteger`, `SetBoolean/GetBoolean`. Chat messages via `AskMsg`, `ResMsg` properties.
+
+**TAiToolBase** - Abstract base for node tools. Inherit and implement `Execute(ANode, AInput, var AOutput)`.
+
+## Creating Custom Tools
+
+```pascal
+uses uMakerAi.Agents, uMakerAi.Agents.Attributes, uMakerAi.Agents.EngineRegistry;
+
+type
+  [TToolAttribute('MyTool', 'Does something useful', 'Custom')]
+  TMyTool = class(TAiToolBase)
+  private
+    [TToolParameterAttribute('API Key', 'Your API key', '')]
+    FApiKey: string;
+  protected
+    procedure Execute(ANode: TAIAgentsNode; const AInput: string; var AOutput: string); override;
+  published
+    property ApiKey: string read FApiKey write FApiKey;
+  end;
+
+initialization
+  TEngineRegistry.Instance.RegisterTool(TMyTool, 'uMyToolUnit');
+```
+
+## JSON Graph Format
+
+GraphBuilder expects this structure:
+```json
+{
+  "nodes": [
+    {
+      "id": "node_guid",
+      "label": "NodeName",
+      "toolClassName": "TMyTool",
+      "parameters": { "ApiKey": "xxx" },
+      "properties": {
+        "engine": { "joinMode": "jmAny", "linkMode": "lmFanout" }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "sourceNodeId": "node1_guid",
+      "targetNodeId": "node2_guid",
+      "sourceTerminal": "out_a"
+    }
+  ]
+}
+```
+
+Port terminals: `out_a`, `out_b`, `out_c`, `out_d`, `out_failure` (maps to NextNo).
+
+## Execution Status
+
+`TAgentExecutionStatus`: `esUnknown`, `esRunning`, `esCompleted`, `esError`, `esTimeout`, `esAborted`
+
+Access via `Blackboard.SetStatus()`/`GetStatus()`.
+
+## Threading Model
+
+- Nodes execute in parallel via TThreadPool
+- `MaxConcurrentTasks` limits concurrent executions
+- TAIBlackboard operations are thread-safe
+- Node callbacks (`OnExecute`) run on worker threads - use `TThread.Synchronize` for UI updates
+
+## Dependencies
+
+Internal: `uMakerAi.Chat`, `uMakerAi.Core`, `uMakerAi.Chat.Messages`
+
+Framework: `System.Threading`, `System.Bindings.*`, `System.Rtti`, `System.JSON`, `System.SyncObjs`
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Source/CLAUDE.md
+++ b/Source/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Source Directory Overview
+
+This is the main source code directory for MakerAI 3.2, an AI orchestration framework for Delphi. See individual module CLAUDE.md files for detailed guidance on specific subsystems.
+
+## Building
+
+### Package Compilation Order (Critical)
+```text
+1. Packages/MakerAI.dpk          - Runtime core (~98 units)
+2. Packages/MakerAi.RAG.Drivers.dpk  - PostgreSQL connectors
+3. Packages/MakerAi.UI.dpk       - FMX visual components
+4. Packages/MakerAiDsg.dpk       - Design-time (requires VCL, DesignIDE)
+```
+
+Open `Packages/MakerAiGrp.groupproj` to compile all packages.
+
+### Required Library Paths
+All subdirectories (Agents, Chat, ChatUI, Core, Design, MCPClient, MCPServer, RAG, Resources, Tools, Utils) must be in Delphi Library Path.
+
+## Module Quick Reference
+
+| Module | Entry Point | Key Classes |
+|--------|-------------|-------------|
+| Core | `uMakerAi.Chat.pas` | `TAiChat` (abstract base), `TAiMediaFile`, `TAiChatMessage` |
+| Chat | `uMakerAi.Chat.AiConnection.pas` | `TAiChatConnection` (universal connector) |
+| RAG | `uMakerAi.RAG.Vectors.pas`, `uMakerAi.RAG.Graph.Core.pas` | `TAiVectorStore`, `TAiRagGraph` |
+| Agents | `uMakerAi.Agents.pas` | `TAIAgentManager`, `TAIAgentsNode`, `TAIBlackboard` |
+| MCPServer | `uMakerAi.MCPServer.Core.pas` | `TAiMCPServer`, `IAiMCPTool` |
+| MCPClient | `uMakerAi.MCPClient.Core.pas` | `TMCPClientItem`, transport classes |
+| Tools | `uMakerAi.Tools.Functions.pas` | `TAiFunctions`, `TFunctionActionItem` |
+| ChatUI | `uMakerAi.UI.ChatList.pas` | `TChatList`, `TChatBubble`, `TChatInput` |
+
+## Architecture Patterns
+
+### Universal Connector
+`TAiChatConnection` abstracts all LLM providers. Switch providers by setting `DriverName`:
+```pascal
+AiConnection.DriverName := 'OpenAI';  // or 'Claude', 'Gemini', 'Ollama', etc.
+AiConnection.Model := 'gpt-5.1-turbo';
+```
+
+### Driver Registration
+New LLM drivers must implement these class methods in `TAiChat` descendant:
+```pascal
+class function GetDriverName: string; override;
+class procedure RegisterDefaultParams(Params: TStrings); override;
+class function CreateInstance(Sender: TComponent): TAiChat; override;
+```
+Register in `uMakerAi.Chat.Initializations.pas`.
+
+### Chat State Machine
+All chat implementations follow: `acsIdle → acsConnecting → [acsReasoning] → acsWriting → [acsToolCalling] → acsFinished/acsError`
+
+### Media File Handling
+`TAiMediaFile` abstracts files across providers. Load with `LoadFromFile()`, attach to messages via `AddMessageAndRun(prompt, role, [mediaFile])`.
+
+### Parameter Hierarchy
+Three levels (lowest to highest priority):
+1. Driver defaults (`RegisterDefaultParams`)
+2. Model overrides (`TAiChatFactory.RegisterModelParam`)
+3. User overrides (`TAiChatFactory.RegisterUserParam`)
+
+Environment variables: Use `@VAR_NAME` syntax (e.g., `@OPENAI_API_KEY`).
+
+## Common Tasks
+
+| Task | Location |
+|------|----------|
+| Add LLM provider | `Chat/uMakerAi.Chat.*.pas` (inherit `TAiChat`) |
+| Add MCP tool | `MCPServer/` (implement `IAiMCPTool`) |
+| Add agent tool | `Agents/` (inherit `TAiToolBase`, register in `TEngineRegistry`) |
+| Modify function calling | `Tools/uMakerAi.Tools.Functions.pas` |
+| Change version/flags | `Core/uMakerAi.Version.inc` |
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for project overview, naming conventions, Delphi version compatibility, thread safety details, troubleshooting, and known issues.
+
+### Module Documentation
+
+| Module | Documentation |
+|--------|---------------|
+| [Core/](Core/CLAUDE.md) | Foundation classes, TAiChat, TAiMediaFile |
+| [Chat/](Chat/CLAUDE.md) | LLM provider drivers |
+| [Agents/](Agents/CLAUDE.md) | Agent orchestration framework |
+| [RAG/](RAG/CLAUDE.md) | Retrieval-Augmented Generation |
+| [MCPServer/](MCPServer/CLAUDE.md) | MCP server implementations |
+| [MCPClient/](MCPClient/CLAUDE.md) | MCP client connector |
+| [Tools/](Tools/CLAUDE.md) | Function calling, Shell, ComputerUse |
+| [ChatUI/](ChatUI/CLAUDE.md) | FMX visual components |
+| [Utils/](Utils/CLAUDE.md) | Voice monitor, diff updater |
+| [Design/](Design/CLAUDE.md) | Design-time property editors |
+| [Resources/](Resources/CLAUDE.md) | Embedded resources |

--- a/Source/Chat/CLAUDE.md
+++ b/Source/Chat/CLAUDE.md
@@ -1,0 +1,123 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+The Chat module contains LLM provider drivers for the MakerAI framework. Each driver implements provider-specific API communication, message formatting, streaming, and tool calling for a different LLM service.
+
+## Module Structure
+
+### Universal Connector
+- `uMakerAi.Chat.AiConnection.pas` - `TAiChatConnection` component that abstracts all provider differences. Set `DriverName` property to switch providers without code changes. Manages tool integration (Shell, TextEditor, ComputerUse, Speech, Video, Vision, WebSearch, Image).
+
+### Provider Drivers
+Each inherits from `TAiChat` (defined in Core):
+
+| File | Class | Provider |
+|------|-------|----------|
+| `uMakerAi.Chat.OpenAi.pas` | `TAiOpenChat` | OpenAI (GPT, o1, o3, Sora) |
+| `uMakerAi.Chat.Claude.pas` | `TAiClaudeChat` | Anthropic Claude |
+| `uMakerAi.Chat.Gemini.pas` | `TAiGeminiChat` | Google Gemini (Veo) |
+| `uMakerAi.Chat.Ollama.pas` | `TAiOllamaChat` | Ollama (local models) |
+| `uMakerAi.Chat.LMStudio.pas` | `TAiLMStudioChat` | LM Studio |
+| `uMakerAi.Chat.Groq.pas` | `TAiGroqChat` | Groq |
+| `uMakerAi.Chat.DeepSeek.pas` | `TAiDeepSeekChat` | DeepSeek |
+| `uMakerAi.Chat.Mistral.pas` | `TAiMistralChat` | Mistral |
+| `uMakerAi.Chat.Kimi.pas` | `TAiKimiChat` | Kimi |
+| `uMakerAi.Chat.Grok.pas` | `TAiGrokChat` | xAI Grok |
+| `uMakerAi.Chat.Cohere.pas` | `TCohereChat` | Cohere |
+| `uMakerAi.Chat.GenericLLM.pas` | `TAiGenericLLM` | OpenAI-compatible APIs |
+
+### Configuration
+- `uMakerAi.Chat.Initializations.pas` - Driver registration and default model parameters. Uses `TAiChatFactory` to configure capabilities per model (media support, tool calling, thinking levels).
+
+### Legacy (Deprecated)
+- `uMakerAi.Chat.OpenAi_Deprecated.pas`
+- `uMakerAi.Chat.Ollama_old.pas`, `uMakerAi.Chat.Ollama_old1.pas`
+- `uMakerAi.Chat.Claude_beta.pas`
+
+## Key Patterns
+
+### Driver Implementation
+All drivers implement these core methods:
+- `Run()` - Execute chat completion (sync or async based on `Asynchronous` property)
+- `GetMessages()` - Serialize message history to provider-specific JSON format
+- `ParseChat()` - Parse provider response into `TAiChatMessage`
+- `GetModels()` - Retrieve available models from API
+
+Streaming drivers additionally implement:
+- `ProcessStreamChunk()` - Handle SSE/streaming response chunks
+- `OnInternalReceiveData` / `OnInternalReceiveDataEnd` - Event callbacks
+
+### Parameter Registry
+Model capabilities are configured via `TAiChatFactory.Instance.RegisterUserParam()`:
+```delphi
+// Global driver defaults
+TAiChatFactory.Instance.RegisterUserParam('Ollama', 'Max_Tokens', '8000');
+
+// Model-specific overrides
+TAiChatFactory.Instance.RegisterUserParam('Ollama', 'llama3.2-vision:latest',
+  'ChatMediaSupports', '[Tcm_Text, Tcm_Image]');
+```
+
+Key parameters:
+- `NativeInputFiles` / `NativeOutputFiles` - Physical file types supported
+- `ChatMediaSupports` - Logical capabilities (`Tcm_Text`, `Tcm_Image`, `Tcm_Audio`, `Tcm_Reasoning`, `Tcm_WebSearch`, `Tcm_CodeInterpreter`)
+- `EnabledFeatures` - Features to enable (may use Bridge for unsupported features)
+- `Tool_Active` - Enable function calling
+- `ThinkingLevel` - Reasoning level (`tlLow`, `tlMedium`, `tlHigh`)
+
+### Chat State Machine
+Drivers follow states in `TAiChatState`:
+```text
+acsIdle → acsConnecting → acsReasoning → acsWriting → acsToolCalling → acsFinished/acsError
+```
+
+### Tool Calling Flow
+1. Message sent with tool definitions
+2. Model responds with `tool_use` block
+3. `OnCallToolFunction` event fires
+4. Tool result appended to messages
+5. `Run()` called again for final response
+
+## Dependencies
+
+- `uMakerAi.Core.pas` - Base types (`TAiMediaFile`, `TAiFileCategory`, `TAiChatState`)
+- `uMakerAi.Chat.pas` - Abstract `TAiChat` base class
+- `uMakerAi.Chat.Messages.pas` - `TAiChatMessage`, `TAiChatMessages`
+- `uMakerAi.Tools.Functions.pas` - `TAiFunctions`, `TAiToolsFunction`
+- `uMakerAi.ParamsRegistry.pas` - `TAiChatFactory` for model configuration
+
+## Adding a New Driver
+
+1. Create `uMakerAi.Chat.NewProvider.pas`
+2. Define class inheriting from `TAiChat`
+3. Implement `Run()`, `GetMessages()`, `ParseChat()`, `GetModels()`
+4. Register in `uMakerAi.Chat.Initializations.pas` initialization section
+5. Configure default parameters via `TAiChatFactory.Instance.RegisterUserParam()`
+
+## Provider-Specific Notes
+
+### Claude
+- Uses `x-anthropic-version` header and beta features via dynamic headers
+- Supports context editing (`TClaudeContextConfig`) for long conversations
+- Thinking/reasoning via `EnableThinking` and `ThinkingBudget`
+- Citations support planned (see TODO in source)
+
+### OpenAI
+- Supports audio models (`gpt-4o-audio-preview`), image generation (DALL-E, gpt-image-1), video (Sora)
+- Reasoning models (o1, o3, GPT-5) use `ThinkingLevel` parameter
+
+### Ollama
+- Default: text-only, no native tools
+- Vision models (llava, llama3.2-vision, qwen2.5-vl) configured with `NativeInputFiles=[Tfc_Image]`
+- Some models support native function calling (`Tool_Active=True`)
+
+### Gemini
+- Native web search, code interpreter capabilities
+- Veo video generation support
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Source/ChatUI/CLAUDE.md
+++ b/Source/ChatUI/CLAUDE.md
@@ -1,0 +1,141 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+ChatUI is a Delphi FMX visual components library providing chat interface components for AI applications. Part of the MakerAI framework. All components are registered in the 'MakerAI UI' component palette.
+
+## Components
+
+### TChatList (`uMakerAi.UI.ChatList.pas`)
+Scrollable chat message container managing bubble layout and persistence.
+- Wraps TVertScrollBox with internal TFlowLayout (`FContentLayout`)
+- Handles message grouping (consecutive same-user messages via `GroupConsecutiveMessages`)
+- JSON-based serialization: `SaveToStream()` / `LoadFromStream()` with version control
+- Properties: `InboundColor`, `OutboundColor`, `MaxBubbleWidthPercent` (0.1-1.0), `AutoScroll`
+- Events forwarded from bubbles: `OnBubbleAvatarClick`, `OnBubbleMoreOptionsClick`, `OnMediaFileDblClick`
+- Attachment context menu: Assign `AttachmentPopupMenu` property, access `ActiveMediaFile` in menu handlers
+
+### TChatBubble (`uMakerAi.UI.ChatBubble.pas`)
+Individual message bubble with rich content support.
+- Custom-painted control with tail styles: `tsSimple`, `tsOrganic`, `tsComic`, `tsSharp`
+- Content via `FContentLayout`: TMemo (text), TImage (images), TLayout (documents)
+- `AddContent(Text, MediaFiles)` - Clears and rebuilds content (media first, text last)
+- `AppendText(Fragment)` - For streaming responses; creates TMemo if needed, calls `OnRecalculateRequired`
+- Header section: Avatar (via `Images`/`ImageIndex` or direct `Avatar` bitmap), Title, Timestamp
+- `TailPosition`: `tpLeft` (inbound) / `tpRight` (outbound)
+- Serialization: `ToJsonObject()` / `LoadFromJsonObject()` with Base64-encoded media
+
+### TChatInput (`uMakerAi.UI.ChatInput.pas`)
+Multi-modal input control with text, media attachments, and voice.
+- Regions: Image carousel (top, visible when attachments exist), TMemo (center), Button bar (bottom)
+- Attachment handling: File dialog, clipboard paste, drag-drop (files + URLs), screenshot
+- `ValidExtensions` property: Comma-separated list (e.g., 'jpg,jpeg,png,pdf,mp3')
+- Voice integration via `VoiceMonitor: TAIVoiceMonitor` property
+- Main event: `OnSendEvent(Sender, Prompt, MediaFiles, AudioStream)`
+- `OnCancel` event triggered when user clicks send button during busy state
+- `Busy` property: When True, shows cancel icon and disables input
+- Call `ChatInput.Busy := False` after processing to re-enable input
+
+### TScreenCapture (`uMakerAi.Utils.ScreenCapture.pas`)
+Screen region selection and capture utility (Windows/macOS).
+- `TScreenCapture.SelectArea(out Rect)`: Shows overlay form for region selection, returns True if selected
+- `TScreenCapture.CaptureArea(Rect)`: Captures specified screen region as TBitmap
+- Supports multi-monitor setups via virtual screen metrics
+
+## Architecture Patterns
+
+**Event Forwarding**: Bubble events propagate through TChatList to consumers.
+
+**Content Layout**: Both TChatBubble and TChatInput use TLayout containers for flexible child positioning.
+
+**Media Abstraction**: Uses `TAiMediaFile` from Core layer for uniform image/document/audio handling.
+
+**State Management**: TChatInput `Busy` property controls UI state (send vs cancel button).
+
+**Size Calculation**: `RecalculateSize(MaxWidth)` measures TMemo content, adds header/padding/icons, constrains to bounds.
+
+**Resource Loading**: Icons loaded from embedded `UIResources.res` via `LoadImageFromResource()`. Document type icons (pdf, doc, audio, video, image, unknown) stored in `FDocIcons` dictionary.
+
+## Thread Safety
+
+- UI updates during streaming must use `TThread.Queue` or `TThread.Synchronize`
+- `TChatInput.DoSendEvent` sets `Busy := True` synchronously before firing event
+- `TChatList.ScrollToBottom` uses `TThread.ForceQueue` to ensure layout is complete
+
+## Serialization Format
+
+Chat history is persisted as JSON with structure:
+```json
+{
+  "version": 1,
+  "bubbles": [
+    {
+      "username": "User",
+      "title": "User",
+      "timestamp": "14:30",
+      "tailPosition": 0,
+      "bubbleColor": 4294967295,
+      "imageIndex": -1,
+      "text": "Hello",
+      "mediaFiles": [...]
+    }
+  ]
+}
+```
+
+## Integration
+
+```delphi
+// Display messages with attachments
+ChatList.AddBubble('Hello', 'User', nil, True);  // Inbound (left tail)
+ChatList.AddBubble('Response', 'Assistant', MediaFiles, False);  // Outbound (right tail)
+
+// Handle input
+procedure TForm1.ChatInput1SendEvent(Sender: TObject; const Prompt: string;
+  MediaFiles: TAiMediaFiles; AudioStream: TMemoryStream);
+begin
+  ChatList.AddBubble(Prompt, 'You', MediaFiles, True);
+  // Process with TAiChat driver, then:
+  ChatList.AddBubble(Response, 'Assistant', nil, False);
+  ChatInput.Busy := False;  // Re-enable input
+end;
+
+// Streaming response
+Bubble := ChatList.AddBubble('', 'Assistant', nil, False);
+// In OnReceiveData callback:
+TThread.Queue(nil, procedure begin
+  Bubble.AppendText(Fragment);  // Progressive rendering
+end);
+
+// Save/restore chat
+ChatList.SaveToStream(FileStream);
+ChatList.LoadFromStream(FileStream);
+
+// Handle attachment double-click
+procedure TForm1.ChatList1MediaFileDblClick(Sender: TObject;
+  const ABubble: TChatBubble; const AMediaFile: TAiMediaFile);
+begin
+  ShellExecute(0, 'open', PChar(AMediaFile.FullFileName), nil, nil, SW_SHOW);
+end;
+```
+
+## Key Constants
+
+```delphi
+// TChatBubble layout
+HEADER_HEIGHT = 30;
+AVATAR_SIZE = 24;
+ICON_SIZE = 16;
+CONTENT_PADDING = 8;
+
+// TChatInput
+IMAGE_WIDTH = 50;    // Attachment thumbnail size
+MAX_MEMO_HEIGHT = 200;
+MIN_FRAME_HEIGHT = 60;
+```
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Source/Core/CLAUDE.md
+++ b/Source/Core/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Source/Core Overview
+
+This folder contains the foundation layer of the MakerAI framework. All provider-specific chat drivers, RAG systems, and UI components depend on these core abstractions.
+
+## Unit Responsibilities
+
+| Unit | Purpose |
+|------|---------|
+| `uMakerAi.Core.pas` | Base types: `TAiMediaFile`, `TAiFileCategory`, `TAiChatMediaSupport`, `TAiChatState`, MIME utilities |
+| `uMakerAi.Chat.pas` | Abstract `TAiChat` base class - all LLM drivers inherit from this |
+| `uMakerAi.Chat.Messages.pas` | `TAiChatMessage`, `TAiChatMessages`, `TAiToolsFunction`, citations system |
+| `uMakerAi.Chat.Tools.pas` | `IAiToolContext` interface and base tool classes (`TAiSpeechToolBase`, `TAiVisionToolBase`, etc.) |
+| `uMakerAi.Chat.Bridge.pas` | Bridge utilities for chat interoperability |
+| `uMakerAi.Embeddings.pas` | OpenAI-specific embedding implementation (inherits from `uMakerAi.Embeddings.core.pas`) |
+| `uMakerAi.Embeddings.core.pas` | Abstract `TAiEmbeddingsCore` base class for embedding providers |
+| `uMakerAi.Prompts.pas` | Prompt template utilities |
+| `uMakerAi.Version.inc` | Version constants and feature flags - included via `{$I}` directive |
+| `uMakerAi.Utils.*.pas` | Utility helpers (CodeExtractor, PcmToWav, System) |
+
+## Key Types and Patterns
+
+### File Category System
+```pascal
+TAiFileCategory = (Tfc_Text, Tfc_Image, Tfc_Audio, Tfc_Video, Tfc_Pdf, ...)
+TAiChatMediaSupport = (Tcm_Text, Tcm_Image, Tcm_Audio, Tcm_Video, Tcm_Pdf, ...)
+```
+`TAiFileCategory` represents physical file types. `TAiChatMediaSupport` represents model capabilities.
+
+### Chat State Machine
+```pascal
+TAiChatState = (acsIdle, acsConnecting, acsCreated, acsReasoning, acsWriting,
+                acsToolCalling, acsToolExecuting, acsFinished, acsAborted, acsError)
+```
+All chat implementations follow this state flow. Use `OnStateChange` event to track transitions.
+
+### TAiChat Abstract Methods
+When creating a new LLM driver, these class methods must be implemented:
+```pascal
+class function GetDriverName: string; virtual; abstract;
+class procedure RegisterDefaultParams(Params: TStrings); virtual; abstract;
+class function CreateInstance(Sender: TComponent): TAiChat; virtual; abstract;
+```
+
+### Tool Context Interface
+`IAiToolContext` allows tools to report events back to the chat without circular dependencies:
+```pascal
+IAiToolContext = interface
+  procedure DoData(Msg: TAiChatMessage; const Role, Text: string; AResponse: TJSONObject = nil);
+  procedure DoDataEnd(Msg: TAiChatMessage; const Role, Text: string; AResponse: TJSONObject = nil);
+  procedure DoError(const ErrorMsg: string; E: Exception);
+  procedure DoStateChange(State: TAiChatState; const Description: string = '');
+  function GetAsynchronous: Boolean;
+end;
+```
+
+## Delphi Version Compatibility
+
+The code uses conditional compilation for Delphi version differences:
+```pascal
+{$IF CompilerVersion >= 34}  // Delphi 10.3 Rio+
+  Client.SynchronizeEvents := False;
+{$IFEND}
+
+{$IF CompilerVersion < 35}
+uses uJSONHelper;  // JSON helper for older Delphi versions
+{$ENDIF}
+```
+
+## Thread Safety
+
+- `TAiChatMessage` uses `TCriticalSection` (`FLock`) for thread-safe media file operations
+- Tool base classes use `TThread.Queue` for reporting events to the main thread
+- Streaming responses are handled asynchronously via `OnReceiveData` event
+
+## Helper Functions
+
+From `uMakerAi.Core.pas`:
+- `GetContentCategory(FileExtension)` - Returns `TAiFileCategory` from file extension
+- `GetMimeTypeFromFileName(FileExtension)` - Returns MIME type string
+- `GetFileExtensionFromMimeType(MimeType)` - Reverse lookup
+- `StreamToBase64(Stream)` - Converts TMemoryStream to Base64 string
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Source/Design/CLAUDE.md
+++ b/Source/Design/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Folder Purpose
+
+This folder contains Delphi IDE design-time support: property editors, component editors, and dialogs that enhance the developer experience when using MakerAI components in the Object Inspector.
+
+## Package
+
+All units in this folder belong to `MakerAiDsg.dpk` (design-time package). This package:
+- Requires VCL and DesignIDE
+- Must be compiled last in the build order (after runtime packages)
+- Cannot be included in runtime applications
+
+## Architecture
+
+### Property/Component Editor Registration
+
+Each editor unit contains a `Register` procedure that hooks into the Delphi IDE:
+
+| Unit | Target | Property | Editor Type |
+|------|--------|----------|-------------|
+| `uAiEditors.ChatConnectionEditor.pas` | `TAiChatConnection` | `DriverName` | Dropdown list of registered drivers |
+| `uMakerAi.VersionPropertyEditor.pas` | `TAiChatConnection` | `Version` | Read-only dialog (About) |
+| `uMCP.ClientEditorProperties.pas` | `TMCPClientItem` | `Configuration` | Modal dialog editor |
+
+### Key Classes
+
+**`TAiChatFactory`** (`UMakerAi.ParamsRegistry.pas`): Singleton factory for driver management
+- `RegisterDriver(AClass)` - Register a chat driver class
+- `GetDriverParams(DriverName, ModelName, Params)` - Get hierarchical params (driver defaults → driver overrides → model overrides)
+- `RegisterUserParam(DriverName, [ModelName,] ParamName, Value)` - Override default params
+- `RegisterCustomModel(DriverName, CustomModelName, BaseModelName)` - Map custom model aliases to base models
+- Environment variable expansion: Values starting with `@` are replaced with the corresponding env var
+
+**`TFMCPClientEditor`** (`uMCPClientEditor.pas`): VCL form for MCP client configuration
+- Supports StdIO, HTTP, SSE, and MakerAi transport types
+- `SetProperties/GetProperties` - Sync UI grid with `Params` and `EnvVars` TStringLists
+- Environment variables are prefixed with `Env:` in the properties grid
+
+## Adding New Property Editors
+
+1. Create a new unit following the `u*.pas` naming convention
+2. Inherit from `TStringProperty`, `TClassProperty`, or other DesignEditors base class
+3. Override `GetAttributes` to define editor behavior (`paValueList`, `paDialog`, `paReadOnly`, etc.)
+4. Override `GetValues` (for dropdowns) or `Edit` (for dialogs)
+5. Call `RegisterPropertyEditor` in the `Register` procedure
+6. Add the unit to `MakerAiDsg.dpk`
+
+## Dependencies
+
+Design units depend on runtime units but not vice versa:
+- `uMakerAi.Chat.AiConnection` (for `TAiChatConnection`)
+- `uMakerAi.Tools.Functions` (for `TMCPClientItem`)
+- `uMakerAi.MCPClient.Core` (for MCP client types)
+- `uMakerAi.Core` (for base types)
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Source/MCPClient/CLAUDE.md
+++ b/Source/MCPClient/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Module Overview
+
+MCPClient implements the Model Context Protocol (MCP) client for MakerAI, enabling Delphi applications to consume external MCP servers through multiple transport protocols. This module follows the MCP Specification (2025-06-18).
+
+## Architecture
+
+### Class Hierarchy
+
+```text
+TMCPClientCustom (Abstract Base)
+├── TMCPClientStdIo   - Local subprocess via stdin/stdout pipes
+├── TMCPClientHttp    - Remote server via HTTP POST JSON-RPC
+├── TMCPClientSSE     - Bidirectional Server-Sent Events streaming
+└── TMCPClientMakerAi - DataSnap-wrapped REST API variant
+```
+
+### Transport Types
+
+| Class | Use Case | Key Component |
+|-------|----------|---------------|
+| `TMCPClientStdIo` | Local MCP server (npx, node) | `TInteractiveProcessInfo` subprocess + read thread |
+| `TMCPClientHttp` | Remote HTTP endpoints | `TNetHTTPClient` with retry logic |
+| `TMCPClientSSE` | Real-time streaming | Async HTTP + `TThreadedQueue` message buffer |
+| `TMCPClientMakerAi` | DataSnap servers | Unwraps nested JSON-RPC from DataSnap array |
+
+### MCP Protocol Flow
+
+1. Send `initialize` request with `protocolVersion: "2025-06-18"`
+2. Receive server capabilities
+3. Send `notifications/initialized` notification
+4. Call `tools/list` to retrieve available tools
+5. Invoke tools via `tools/call`
+
+## Key Patterns
+
+**Thread-Safe Messaging**: StdIo and SSE use `TThreadedQueue<TJSONObject>` for async response handling.
+
+**Media Extraction**: `ProcessAndExtractMedia()` extracts base64-encoded binary content from tool responses into `TAiMediaFile` objects.
+
+**Default Parameters**:
+```text
+Command=npx
+Arguments=@
+RootDir=<home-path>
+Timeout=15000
+URL=http://localhost:3001/sse
+```
+
+## Integration Points
+
+- **TAiFunctions**: MCP clients registered via `MCPClients` collection property
+- **Design-Time Editor**: `TFMCPClientEditor` in `Source/Design/uMCPClientEditor.pas`
+- **Package**: Included in `Source/Packages/MakerAI.dpk`
+
+## Dependencies
+
+- `uMakerAi.Utils.System` - Subprocess management (`TUtilsSystem.StartInteractiveProcess`)
+- `uMakerAi.Core` - Core types (`TAiMediaFile`, `TToolTransportType`)
+- `uJSONHelper` - JSON parsing utilities
+
+## Known Limitations
+
+- SSE transport is experimental (intermittent connectivity per parent CLAUDE.md)
+- `FBusy` flag prevents concurrent operations on same client
+- Windows-focused subprocess management (`{$IFDEF MSWINDOWS}`)
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Source/MCPServer/CLAUDE.md
+++ b/Source/MCPServer/CLAUDE.md
@@ -1,0 +1,168 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Module Overview
+
+MakerAI MCP Server - A Model Context Protocol implementation for Delphi that exposes AI-callable tools and resources through multiple transport protocols (HTTP, SSE, StdIO, Direct). Part of MakerAI 3.x framework.
+
+## Building
+
+MCPServer is included in the main MakerAI runtime package:
+
+```text
+Open: Source/Packages/MakerAI.dpk
+Build → Compile
+```
+
+**IDE:** RAD Studio (Delphi 11 Alexandria to 13 Florence)
+
+**Required library paths:** `Source/MCPServer`, `Source/Core`, `Source/Tools`, `Source/Utils`
+
+## Testing
+
+No dedicated test framework. Testing via demo projects with HTTP/curl.
+
+**Run demo server:**
+```bash
+# SSE protocol (default)
+AiMCPServerDemo.exe --protocol sse --port 8080 --cors-origins "*"
+
+# HTTP protocol
+AiMCPServerDemo.exe --protocol http --port 8080
+
+# Stdio protocol
+AiMCPServerDemo.exe --protocol stdio
+```
+
+**Test via curl:**
+```bash
+# List tools
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+
+# Call a tool
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"system_info","arguments":{"type":"basic"}},"id":2}'
+```
+
+## Architecture
+
+### Class Hierarchy
+
+```text
+TAiMCPLogicServer (JSON-RPC engine, tool/resource registry)
+    └── TAiMCPServer (TComponent wrapper)
+            ├── TAiMCPHttpServer (stateless HTTP JSON-RPC)
+            ├── TAiMCPSSEHttpServer (bidirectional event streaming)
+            ├── TAiMCPStdioServer (stdin/stdout for subprocess)
+            └── TAiMCPDirectConnection (in-process, zero network)
+```
+
+### Key Interfaces
+
+**IAiMCPTool** - Tool contract:
+- `GetName`, `GetDescription`, `GetInputSchema`
+- `Execute(Arguments: TJSONObject; AuthContext: TAiAuthContext): TJSONObject`
+
+**IAiMCPResource** - Resource contract:
+- `GetURI`, `GetName`, `GetDescription`, `GetMimeType`, `Read`
+
+### Units
+
+| Unit | Purpose |
+|------|---------|
+| `uMakerAi.MCPServer.Core.pas` | Core classes, JSON-RPC engine, tool/resource registry (~1,500 lines) |
+| `UMakerAi.MCPServer.Http.pas` | HTTP transport with CORS support |
+| `UMakerAi.MCPServer.SSE.pas` | Server-Sent Events transport (session-aware) |
+| `UMakerAi.MCPServer.Stdio.pas` | Standard I/O transport |
+| `UMakerAi.MCPServer.Direct.pas` | In-process direct invocation |
+| `uMakerAi.MCPServer.Bridge.pas` | Adapter bridging TAiFunctions to IAiMCPTool |
+
+### Tool Implementation Pattern
+
+```delphi
+type
+  TMyParams = class
+  private
+    FPath: string;
+    FRecursive: Boolean;
+  public
+    [AiMCPSchemaDescription('Directory to process')]
+    property Path: string read FPath write FPath;
+    [AiMCPOptional]
+    [AiMCPSchemaDescription('Include subdirectories')]
+    property Recursive: Boolean read FRecursive write FRecursive;
+  end;
+
+  TMyTool = class(TAiMCPToolBase<TMyParams>)
+  protected
+    function ExecuteWithParams(const AParams: TMyParams;
+      const AuthContext: TAiAuthContext): TJSONObject; override;
+  public
+    constructor Create; override;
+  end;
+
+// Registration
+Server.RegisterTool('my_tool',
+  function: IAiMCPTool begin Result := TMyTool.Create; end);
+```
+
+### Schema Attributes
+
+- `[AiMCPSchemaDescription('...')]` - Parameter description for JSON Schema
+- `[AiMCPOptional]` - Mark parameter as optional
+- `[AiMCPSchemaEnum(['a', 'b', 'c'])]` - Enum constraint
+
+### Response Builder
+
+```delphi
+Result := TAiMCPResponseBuilder.New
+  .AddText('Processing complete')
+  .AddFile('/path/to/output.pdf')
+  .Build;
+```
+
+### Protocol Selection
+
+| Protocol | Use Case |
+|----------|----------|
+| HTTP | Simple clients, stateless interactions, load balancing |
+| SSE | Claude Desktop, MakerAI clients, real-time streaming |
+| StdIO | Local subprocess, CLI integration |
+| Direct | Embedded integration, testing, same-process calls |
+
+### MCP Protocol Methods
+
+| Method | Purpose |
+|--------|---------|
+| `initialize` | Server capability handshake |
+| `tools/list` | List available tools |
+| `tools/call` | Execute tool with arguments |
+| `resources/list` | List available resources |
+| `resources/read` | Read resource content |
+
+## Demo Projects
+
+| Demo | Location | Description |
+|------|----------|-------------|
+| 031-MCPServer | `/Demos/031-MCPServer/` | Multi-protocol showcase with FileAccess, SysInfo, WorldTime tools |
+| 035-MCPServerWithTAiFunctions | `/Demos/035-MCPServerWithTAiFunctions/` | TAiFunctions bridge integration |
+| 036-MCPServerStdIO_AiFunction | `/Demos/036-MCPServerStdIO_AiFunction/` | StdIO + TAiFunctions |
+
+## Known Issues
+
+- MCP SSE Server is experimental (intermittent connectivity)
+- Linux compilation requires manual path adjustments
+- No built-in authentication (`OnValidateRequest` event is stubbed)
+
+## Documentation
+
+- `/Docs/Version 3/MCPServer/uMakerAi-MCP.Server.EN.pdf` - English documentation
+- `/Docs/Version 3/MCPServer/uMakerAi-MCP.Server.ES.pdf` - Spanish documentation
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Source/RAG/CLAUDE.md
+++ b/Source/RAG/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Module Overview
+
+The RAG (Retrieval-Augmented Generation) module provides two complementary retrieval systems:
+- **Vector RAG** (`TAiRAGVector`): Embedding-based semantic search with hybrid BM25 support
+- **Graph RAG** (`TAiRagGraph`): Knowledge graph with semantic search over nodes and edges
+
+Both systems share common infrastructure for embeddings, metadata filtering, and database drivers.
+
+## Architecture
+
+### Core Components
+
+```text
+uMakerAi.RAG.Vectors.Index.pas   # Base classes: TAiEmbeddingNode, TAIEmbeddingIndex, THNSWIndex, TAIBm25Index
+uMakerAi.RAG.MetaData.pas        # TAiEmbeddingMetaData, TAiFilterCriteria (filter tree)
+uMakerAi.RAG.Vectors.pas         # TAiRAGVector - main vector store component
+uMakerAi.RAG.Vectors.VQL.pas     # VGQL query language (Lexer, Parser, Compiler)
+uMakerAi.RAG.Graph.Core.pas      # TAiRagGraph, TAiRagGraphNode, TAiRagGraphEdge
+uMakerAi.RAG.Graph.GQL.pas       # MakerGQL query language for graphs
+uMakerAi.RAG.Graph.Builder.pas   # Graph construction helpers
+```
+
+### Inheritance Hierarchy
+
+```text
+TAiEmbeddingNode (base embedding container)
+├── TAiRagGraphNode (graph node with edges)
+└── TAiRagGraphEdge (graph edge with weight)
+
+TAIEmbeddingIndex (abstract index)
+├── TAIBasicEmbeddingIndex (brute force)
+├── THNSWIndex (HNSW approximate search)
+└── TAIEuclideanDistanceIndex (L2 distance)
+
+TAiVectorStoreDriverBase (abstract DB driver)
+└── [PostgreSQL driver in uMakerAi.RAG.Vector.Driver.Postgres]
+
+TAiRagGraphDriverBase (abstract graph DB driver)
+└── [PostgreSQL driver in uMakerAi.RAG.Graph.Driver.Postgres]
+```
+
+## Key Patterns
+
+### Vector Search Options
+
+`TAiSearchOptions` controls hybrid search behavior:
+- `UseEmbeddings`: Enable semantic vector search (cosine similarity)
+- `UseBM25`: Enable lexical search (BM25 algorithm)
+- `UseRRF`: Reciprocal Rank Fusion vs Weighted Score Fusion
+- `UseReorderABC`: Lost-in-the-middle reordering for LLM context
+
+### Filter Criteria System
+
+`TAiFilterCriteria` supports recursive filter trees with operators:
+- Basic: `foEqual`, `foNotEqual`, `foGreater`, `foLess`, etc.
+- Text: `foContains`, `foLike`, `foILike`, `foStartsWith`, `foEndsWith`
+- Lists: `foIn`, `foNotIn`, `foBetween`
+- Existence: `foIsNull`, `foIsNotNull`, `foExists`
+
+Logical grouping via `loAnd`/`loOr` with nested `AddGroup()`.
+
+### VGQL Query Language (Vector)
+
+SQL-like DSL for vector searches:
+```sql
+MATCH documents
+SEARCH 'machine learning algorithms'
+USING HYBRID WEIGHTS(semantic: 0.7, lexical: 0.3) FUSION RRF
+WHERE category = 'tech' AND date > '2024-01-01'
+THRESHOLD GLOBAL 0.5
+RERANK 'neural networks' WITH REGENERATE
+OPTIMIZE REORDER ABC
+RETURN TEXT, METADATA, SCORE
+LIMIT 10
+```
+
+Execution flow: `TVGQLLexer` → `TVGQLParser` → `TVGQLQuery` (AST) → `TVGQLCompiler` → `TVGQLRequest` → `TAiRAGVector.ExecuteVGQL()`
+
+### MakerGQL Query Language (Graph)
+
+Cypher-like DSL for graph traversal:
+```cypher
+MATCH (p:Persona)-[r:TRABAJA_EN]->(e:Empresa)
+WHERE p.ciudad = 'Madrid' AND e.empleados > 100
+RETURN p, r, e
+DEPTH 2
+```
+
+Special commands:
+- `SHOW LABELS` / `SHOW EDGES`: Introspection
+- `GET SHORTEST PATH`: Dijkstra's algorithm
+- `GET CENTRALITY(node)`: Closeness centrality
+- `GET DEGREES TOP n`: Hub detection
+
+## Thread Safety
+
+- `TAiRAGVector` uses `TMultiReadExclusiveWriteSynchronizer` for concurrent access
+- Search results use `TAiSearchResult` record to avoid modifying original nodes
+- Index operations (HNSW) are write-locked during updates
+
+## Component Registration
+
+Both `TAiRAGVector` and `TAiRagGraph` register under the `MakerAI` palette category:
+```pascal
+RegisterComponents('MakerAI', [TAiRAGVector]);
+RegisterComponents('MakerAI', [TAiRagGraph]);
+```
+
+## Graph Export Formats
+
+`TAiRagGraph.SaveToFile()` supports:
+- `gefDOT`: GraphViz format
+- `gefGraphML`: Standard XML format (compatible with Gephi)
+- `gefGraphMkai`: Native JSON format with embeddings
+
+## Database Drivers
+
+External persistence requires implementing:
+- `TAiVectorStoreDriverBase.Add()`, `Search()`, `Delete()`, `Clear()`
+- `TAiRagGraphDriverBase.FindNodeByID()`, `AddNode()`, `AddEdge()`, `SearchNodes()`, etc.
+
+PostgreSQL implementations use pgvector extension for vector similarity.
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Source/Resources/CLAUDE.md
+++ b/Source/Resources/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Purpose
+
+This folder contains Delphi IDE component palette icons for MakerAI components. The icons appear in the Delphi component palette when components are installed.
+
+## Structure
+
+- `icons/` - 24x24 BMP bitmap files for each component
+- `uMakerAiResources.rc` - Resource script linking bitmaps to component class names
+- `uMakerAiResources.RES` - Compiled resource file (auto-generated)
+
+## Adding a New Component Icon
+
+1. Create a 24x24 pixel BMP file named `T[ComponentName]_24.bmp` in `icons/`
+2. Add an entry to `uMakerAiResources.rc` in the appropriate category section:
+   ```
+   T[COMPONENTNAME]  BITMAP "icons\T[ComponentName]_24.bmp"
+   ```
+   Note: The resource name (left side) must be UPPERCASE and match the class name exactly
+3. Recompile the resource file:
+   ```
+   brcc32 uMakerAiResources.rc
+   ```
+   (BRCC32 is in Delphi's `bin` directory, e.g., `C:\Program Files (x86)\Embarcadero\Studio\23.0\bin`)
+
+## Naming Convention
+
+- Icon filename: `T[ComponentName]_24.bmp` (matches class name, 24px size suffix)
+- Resource identifier: `T[COMPONENTNAME]` (uppercase, no suffix)
+- Some identifiers use shortened names (e.g., `TAIOPENCHAT` for `TAiOpenAIChat`)
+
+## RC File Categories
+
+The resource script organizes icons by component category:
+- CORE COMPONENTS - `TAiChatConnection`
+- CHAT COMPONENTS - Provider-specific chat drivers
+- AI SERVICES - Whisper, DALL-E, VoiceMonitor
+- MCP SERVICES - MCP server components
+- EMBEDDINGS - Embedding providers
+- RAG COMPONENTS - Vector and graph RAG
+- AGENTS - Agent system components
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Source/Tools/CLAUDE.md
+++ b/Source/Tools/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Tools Module Overview
+
+The `Source/Tools/` directory contains capability components that extend LLM functionality beyond basic chat. These are standalone components that can be attached to chat instances to enable function calling, media generation, shell execution, and computer automation.
+
+## Unit Categories
+
+### Function Calling System
+- `uMakerAi.Tools.Functions.pas` - Core function calling infrastructure
+  - `TAiFunctions` - Component for defining callable functions with parameters
+  - `TFunctionActionItem` - Individual function definition with `FunctionName`, `Description`, `Parameters`
+  - `TFunctionParamsItem` - Parameter definition with `ParamType` (ptString, ptInteger, ptBoolean, etc.)
+  - `TMCPClientItem` - MCP server connection management within functions
+
+### Agent Automation Tools
+- `uMakerAi.Tools.Shell.pas` - Interactive shell execution (`TAiShell`)
+  - Persistent session via `FSession: TInteractiveProcessInfo`
+  - Auto-detects JSON format from Claude/OpenAI/Generic providers
+  - Events: `OnCommand`, `OnConsoleLog`
+
+- `uMakerAi.Tools.TextEditor.pas` - File editing tool (`TAiTextEditorTool`)
+  - Commands: `Cmd_View`, `Cmd_Create`, `Cmd_StrReplace`, `Cmd_Insert`, `Cmd_ApplyDiff`
+  - Event-based I/O virtualization (can target memory/DB instead of disk)
+  - Set `Handled := True` in events to override default file system behavior
+
+- `uMakerAi.Tools.ComputerUse.pas` - Computer automation (`TAiComputerUseTool`)
+  - Handles Gemini's normalized coordinates (0-1000) conversion to screen pixels
+  - Action types: click, drag, type, scroll, navigate, screenshot
+  - Platform implementations in `*.Windows.pas` and `*.WindowsFMX.pas`
+
+### Media Generation Tools
+- `uMakerAi.OpenAi.Dalle.pas` - Image generation (`TAiDalle`)
+  - Supports dall-e-2, dall-e-3, gpt-image-1
+  - Streaming with `OnPartialImageReceived`, `OnStreamCompleted`
+
+- `uMakerAi.OpenAI.Sora.pas` - Video generation (`TAiSoraGenerator`)
+  - Async methods: `GenerateFromText`, `GenerateFromImage`, `RemixVideo`
+  - Polling-based job completion
+
+- `uMakerAi.Gemini.Video.pas` - Veo video generation (`TAiGeminiVideoTool`)
+  - Inherits from `TAiVideoToolBase`
+  - Properties: `AspectRatio`, `Resolution`, `DurationSeconds`, `PersonGeneration`
+
+### Speech/Audio Tools
+- `uMakerAi.Whisper.pas` - OpenAI Whisper compatibility (legacy)
+- `uMakerAi.OpenAI.Audio.pas` - Modern OpenAI audio (`TAiOpenAiAudio`)
+  - TTS with streaming (`OnAudioChunkReceived`)
+  - Transcription with GPT-4o support and diarization
+
+- `uMakerAi.Gemini.Speech.pas` - Gemini TTS (`TAiGeminiSpeechTool`)
+  - Multi-voice support: `"Anya=Kore, Liam=Puck"`
+  - Director's notes and audio profile configuration
+
+### Utility Tools
+- `uMakerAi.Gemini.WebSearch.pas` - Web search grounding
+- `uMakerAi.Ollama.Ocr.pas` - OCR via Ollama vision models
+
+## Key Patterns
+
+### Tool Base Classes
+Media tools inherit from base classes in `uMakerAi.Chat.Tools.pas`:
+- `TAiSpeechToolBase` - TTS and transcription
+- `TAiVideoToolBase` - Video generation
+
+### Event-Driven Design
+All tools use events for extensibility:
+```pascal
+// Shell intercepts commands before execution
+FOnCommand: TAiShellCommandEvent;
+// TextEditor virtualizes file I/O
+FOnLoadFile: TAiFileReadEvent;
+FOnSaveFile: TAiFileWriteEvent;
+```
+
+### Provider-Agnostic Execution
+Shell and TextEditor auto-detect provider format:
+```pascal
+function ExecuteClaudeAction(const CallId: string; JArgs: TJSONObject): string;
+function ExecuteOpenAIAction(const CallId: string; JArgs: TJSONObject): string;
+function ExecuteGenericAction(const CallId: string; JArgs: TJSONObject): string;
+```
+
+## Dependencies
+
+All tools depend on:
+- `uMakerAi.Core` - `TAiMediaFile`, base types
+- `uMakerAi.Chat.Messages` - `TAiChatMessage`, `TAiToolsFunction`
+
+Some tools require additional utils:
+- `uMakerAi.Utils.System` - Process management for shell
+- `uMakerAi.Utils.DiffUpdater` - Diff application for text editor
+- `uMakerAi.Utils.PcmToWav` - Audio format conversion
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.

--- a/Source/Utils/CLAUDE.md
+++ b/Source/Utils/CLAUDE.md
@@ -1,0 +1,131 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Module Overview
+
+The Utils module provides cross-platform utility classes for MakerAI. These are standalone helpers that support AI agent capabilities but are not tied to specific LLM providers.
+
+## Units
+
+### uMakerAi.Utils.DiffUpdater
+Applies unified diff patches to text content. Used by AI code editing tools.
+
+Key classes:
+- `TDiffParser` - Parses unified diff format into `TDiffHunk` objects
+- `TDiffApplier` - Applies parsed hunks to original content with fuzzy matching
+
+Usage:
+```pascal
+var
+  Applier: TDiffApplier;
+  NewContent, ErrorMsg: string;
+begin
+  Applier := TDiffApplier.Create;
+  try
+    if Applier.Apply(OriginalContent, DiffText, NewContent, ErrorMsg) then
+      // NewContent contains the patched result
+    else
+      // ErrorMsg contains the failure reason
+  finally
+    Applier.Free;
+  end;
+end;
+```
+
+Features:
+- Fuzzy hunk positioning (+/- 20 lines search radius)
+- Tolerates missing/malformed hunk headers (fallback to content-based matching)
+- Ignores trailing whitespace differences
+
+### uMakerAi.Utils.Python
+Executes Python scripts from Delphi using Python4Delphi (P4D).
+
+Key class: `TUtilsPython`
+
+Requirements:
+- Python 3.10+ installed
+- Python4Delphi component
+- **64-bit compilation required** if Python is 64-bit (raises `EPythonArchitectureError` otherwise)
+
+Usage:
+```pascal
+// Without parameters
+Result := TUtilsPython.ExecuteScript('result = 2 + 2');
+
+// With parameters (accessed as param1, param2, etc.)
+Result := TUtilsPython.ExecuteScript('result = param1 ** param2', [2, 8]);
+```
+
+Rules:
+- Scripts must assign output to variable named `result`
+- Parameters are injected as `param1`, `param2`, etc.
+- Supports String, Integer, Float, Boolean, DateTime variant types
+- Global engine instance (`GlPythonEngine`) is reused across calls
+
+### uMakerAi.Utils.ScreenCapture
+Cross-platform screen capture for FMX applications.
+
+Key class: `TScreenCapture` (all static methods)
+
+Platform support:
+- **Windows**: Full support with multi-monitor (virtual screen coordinates)
+- **macOS**: Full support via CoreGraphics
+- **Android**: Not implemented (requires Media Projection API)
+- **iOS**: Not supported (system restriction)
+
+Usage:
+```pascal
+// Full screen capture
+Bitmap := TScreenCapture.CaptureFullScreen;
+
+// Area capture
+Bitmap := TScreenCapture.CaptureArea(TRect.Create(0, 0, 800, 600));
+
+// Interactive selection (Windows only)
+if TScreenCapture.SelectArea(SelectedRect) then
+  Bitmap := TScreenCapture.CaptureArea(SelectedRect);
+```
+
+### uMakerAi.Utils.VoiceMonitor
+Real-time voice activity detection component for speech-to-text workflows.
+
+Key class: `TAIVoiceMonitor` (TComponent - can be dropped on forms)
+
+Platform support:
+- **Windows**: WaveIn API
+- **Android**: AudioRecord with permission handling
+
+State machine: `msIdle` -> `msCalibrating` -> `msMonitoring` -> (back to Idle or Error)
+
+Key features:
+- Auto-calibration of ambient noise level (3 seconds by default)
+- Configurable sensitivity multipliers for start/stop thresholds
+- Wake word detection support via `OnWakeWordCheck` event
+- Real-time transcription fragments via `OnTranscriptionFragment`
+- Outputs WAV format streams
+
+Key properties:
+- `Active` - Start/stop monitoring
+- `SilenceDuration` - Ms of silence before speech end (default 1000)
+- `WakeWordActive` / `WakeWord` - Enable wake word detection
+- `SensitivityMultiplier` / `StopSensitivityMultiplier` - Threshold tuning
+
+Key events:
+- `OnCalibrated` - Fired after noise calibration completes
+- `OnChangeState` - Speaking started/stopped
+- `OnSpeechEnd` - Final WAV stream ready
+- `OnTranscriptionFragment` - Incremental audio chunks during speech
+- `OnUpdate` - Real-time sound level updates
+
+Thread safety:
+- Uses `TCriticalSection` for buffer access
+- Events are dispatched via `TThread.Queue` to main thread
+
+## Platform Considerations
+
+Windows-specific code uses `{$IFDEF MSWINDOWS}` conditionals. Android uses `{$IFDEF ANDROID}`. When adding new utilities, follow this pattern for cross-platform support.
+
+## Navigation
+
+> See [../CLAUDE.md](../CLAUDE.md) for source directory overview and [../../CLAUDE.md](../../CLAUDE.md) for project overview.


### PR DESCRIPTION
## Summario
 41 archivos CLAUDE.md cubriendo visión general del proyecto, arquitectura, módulos de código fuente, demos, docs y utilidades. Proporciona a Claude Code instrucciones de compilación, convenciones de nombres, notas de thread safety, dependencias, variables de entorno, manejo de errores y navegación.

## Archivos incluidos
  - `CLAUDE.md` (raíz) — Visión general completa del proyecto
  - 12 archivos en `Source/` — Documentación por módulo
  - 18 archivos en `Demos/` — Documentación por demo
  - 5 archivos en `Docs/` — Índice de documentación externa
  - Otros: `Redis/`, `Resources/`
