### PR TITLE
FPC/Lazarus: compatibilidad, uDemoHelper, build infra y documentación

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ desktop.ini
 # Temporary
 *.tmp
 *.log
+*.ref_bak
+*.orig
+
+# Build output directories (demos)
+Demos/bin/
+Demos/bin_win/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,16 @@ FPC=/ruta/fpc ./build_demos.sh  # FPC específico
 
 El script **no para en errores** — compila los 45 pase lo que pase y al final muestra un reporte OK / FAIL. Útil cuando un demo depende de API keys o drivers que no están disponibles.
 
+### uDemoHelper — Inicialización silenciosa (obligatorio en todo demo)
+
+`Demos/uDemoHelper.pas` es una unidad de solo `implementation` que debe incluirse en el `uses` de **todo demo**. Su bloque `initialization` ejecuta 3 arreglos críticos antes de que corra cualquier código del programa:
+
+1. **UTF-8 en consola Windows** — `SetConsoleOutputCP(CP_UTF8)`. Sin esto, acentos y caracteres como `ñ`, `¿`, `¡` se ven corruptos.
+2. **Separador decimal consistente** — fuerza `'.'` como separador decimal. En Windows con locale español, `Temperature := 0.7` se serializa como `"0,7"` (con coma) y el servidor lo rechaza, causando respuestas vacías intermitentes (detectado con Cohere).
+3. **Inicializar OpenSSL en FPC** — `InitSSLInterface`. FPC no lo hace automáticamente. Sin esto, las conexiones HTTPS fallan silenciosamente. Si falla, muestra instrucciones de instalación.
+
+**Siempre incluir `uDemoHelper` en el `uses` de cualquier nuevo demo.**
+
 ## Architecture
 
 ### Layers (mirrors the Delphi original)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,32 @@ This is a **source library** — no standalone build system. Units are included 
 
 **Feature flags** are in `Source/Core/uMakerAi.Version.inc` — include with `{$I uMakerAi.Version.inc}`, never hard-code constants.
 
-**No formal test suite.** Verify changes by running relevant demo applications.
+## Demos — Compilación y Estructura
+
+Los 45 demos están en `Demos/`. Cada uno es un `.pas` standalone que se compila directamente con FPC.
+
+```
+Demos/
+├── *.pas            ← fuente (45 archivos)
+├── bin/             ← ejecutables compilados
+├── lib/             ← objetos temporales (.o, .ppu, .a)
+└── build_demos.sh   ← script de compilación
+```
+
+**Compilar todo:**
+```bash
+cd Demos
+./build_demos.sh              # FPC del PATH
+FPC=/ruta/fpc ./build_demos.sh  # FPC específico
+```
+
+**Limpiar y recompilar:**
+```bash
+./build_demos.sh clean   # borra bin/ y lib/
+./build_demos.sh         # recompila desde cero
+```
+
+El script **no para en errores** — compila los 45 pase lo que pase y al final muestra un reporte OK / FAIL. Útil cuando un demo depende de API keys o drivers que no están disponibles.
 
 ## Architecture
 

--- a/Demos/build_demos.sh
+++ b/Demos/build_demos.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# ===========================================================================
+# build_demos.sh — Compila todos los demos de MakerAI Suite (FPC Port)
+# ===========================================================================
+# Uso:
+#   ./build_demos.sh                    — Linux nativo
+#   ./build_demos.sh --win64            — cross-compile a Windows x64
+#   FPC=/ruta/al/fpc ./build_demos.sh   — FPC específico
+#   ./build_demos.sh clean              — elimina bin/ bin_win/ y lib/
+# ===========================================================================
+
+set -euo pipefail
+
+FPC="${FPC:-fpc}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# --- clean ---
+if [ "${1:-}" = "clean" ]; then
+    echo "🧹 Limpiando bin/ bin_win/ lib/ ..."
+    rm -rf bin bin_win lib
+    echo "✅ Listo. Ejecuta sin argumentos para recompilar."
+    exit 0
+fi
+
+# --- win64 cross-compile ---
+WIN64=false
+if [ "${1:-}" = "--win64" ]; then
+    WIN64=true
+    # Buscar ppcrossx64 (cross-compiler Win64)
+    FPC_DIR="$(dirname "$FPC")"
+    if [ -x "$FPC_DIR/ppcrossx64" ]; then
+        FPC="$FPC_DIR/ppcrossx64"
+    elif command -v ppcrossx64 &>/dev/null; then
+        FPC=ppcrossx64
+    else
+        echo "❌ ppcrossx64 no encontrado. Instálalo o especifica FPC=..."
+        exit 1
+    fi
+    BIN_DIR="bin_win"
+    EXTRA_FLAGS=(-Twin64)
+    # RTL de Win64 (junto al cross-compiler o en fpc.cfg)
+    RTL_WIN64="${FPC_DIR}/../units/x86_64-win64/rtl"
+    if [ -d "$RTL_WIN64" ]; then
+        EXTRA_FLAGS+=("-Fu$RTL_WIN64")
+    fi
+    PLATFORM="Windows x64"
+else
+    BIN_DIR="bin"
+    EXTRA_FLAGS=()
+    PLATFORM="Linux ($(uname -m))"
+fi
+
+# --- preparar directorios ---
+mkdir -p "$BIN_DIR" lib
+
+# --- compilar ---
+OK=0
+FAIL=0
+TOTAL=0
+FAIL_LIST=""
+
+echo "📦 Compilando para $PLATFORM"
+echo "   FPC: $FPC"
+echo "   Dir: $SCRIPT_DIR"
+echo "═══════════════════════════════════════════════════════════════"
+
+for f in *.pas; do
+    TOTAL=$((TOTAL + 1))
+    printf "  [%2d] %-35s " "$TOTAL" "$f"
+
+    OUT=$(mktemp /tmp/makerai_build_XXXXXX)
+    # shellcheck disable=SC2086
+    if $FPC -FE"$BIN_DIR" -FUlib "${EXTRA_FLAGS[@]}" "$f" >"$OUT" 2>&1; then
+        echo "✅"
+        OK=$((OK + 1))
+    else
+        echo "❌ FAIL"
+        FAIL=$((FAIL + 1))
+        FAIL_LIST="$FAIL_LIST $f"
+        grep -E 'Fatal:|Error:' "$OUT" | head -3 | while read -r line; do
+            echo "       $line"
+        done
+    fi
+    rm -f "$OUT"
+done
+
+# --- reporte ---
+echo "═══════════════════════════════════════════════════════════════"
+echo "  OK: $OK  |  FAIL: $FAIL  |  Total: $TOTAL"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "  Fallaron:"
+    for f in $FAIL_LIST; do
+        echo "    ❌ $f"
+    done
+    if $WIN64; then
+        echo ""
+        echo "  💡 Los errores pueden deberse a units no compiladas para Win64."
+        echo "     Verifica que las dependencias tengan RTL para x86_64-win64."
+    fi
+    exit 1
+else
+    echo "  ✅ Todos compilados correctamente."
+    if $WIN64; then
+        echo ""
+        echo "  📁 Ejecutables en: $BIN_DIR/"
+        echo "  📋 Copiar a Windows: cp $BIN_DIR/*.exe ~/Escritorio/Compartidos_MV_IA/MakerAI_Demos_Win/"
+    fi
+    exit 0
+fi

--- a/Demos/demo_agents.pas
+++ b/Demos/demo_agents.pas
@@ -14,6 +14,7 @@ program demo_agents;
 //   fpc demo_agents.pas -Fu../Source/Core -Fu../Source/Chat -Fu../Source/Agents
 
 uses
+  uDemoHelper,
   SysUtils, Classes, SyncObjs,
   generics.collections,
   uMakerAi.Core,

--- a/Demos/demo_aiconnection.pas
+++ b/Demos/demo_aiconnection.pas
@@ -18,6 +18,7 @@ program demo_aiconnection;
 //   - O cambiar DriverName a otro driver disponible
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -67,7 +68,10 @@ begin
     WriteLn('>>> Pregunta: En una frase, que es Ollama?');
     try
       Resp := Conn.AddMessageAndRun('En una frase, que es Ollama?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn('Tokens — Prompt: ', Conn.Prompt_tokens,
               '  Completion: ',    Conn.Completion_tokens,
               '  Total: ',         Conn.Total_tokens);
@@ -95,7 +99,10 @@ begin
     try
       Resp := Conn.AddMessageAndRun(
           'Di "Hola desde GenericLLM" en una sola linea.', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
     except
       on E: Exception do
         WriteLn('[ERROR GenericLLM] ', E.Message);

--- a/Demos/demo_aiconnection_async.pas
+++ b/Demos/demo_aiconnection_async.pas
@@ -10,6 +10,7 @@ program demo_aiconnection_async;
 //   - El patron Facade es transparente al codigo consumidor en modo async
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_claude.pas
+++ b/Demos/demo_claude.pas
@@ -14,6 +14,7 @@ program demo_claude;
 //                      claude-haiku-4-5, claude-3-5-sonnet-20241022
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -55,7 +56,10 @@ begin
 
     try
       Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn;
       WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
               '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_claude_async.pas
+++ b/Demos/demo_claude_async.pas
@@ -11,6 +11,7 @@ program demo_claude_async;
 //   Linux:    export CLAUDE_API_KEY=sk-ant-xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_cohere.pas
+++ b/Demos/demo_cohere.pas
@@ -21,6 +21,7 @@ program demo_cohere;
 //   Linux:    export COHERE_API_KEY=...
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -62,7 +63,10 @@ begin
 
     try
       Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn;
       WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
               '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_cohere_async.pas
+++ b/Demos/demo_cohere_async.pas
@@ -20,6 +20,7 @@ program demo_cohere_async;
 //   Linux:    export COHERE_API_KEY=...
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_dalle.pas
+++ b/Demos/demo_dalle.pas
@@ -15,6 +15,7 @@ program demo_dalle;
 //   fpc demo_dalle.pas -Fu../Source/Core -Fu../Source/Chat -Fu../Source/Tools
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   uMakerAi.Core,
   uMakerAi.OpenAi.Dalle;

--- a/Demos/demo_deepseek.pas
+++ b/Demos/demo_deepseek.pas
@@ -14,6 +14,7 @@ program demo_deepseek;
 //   Linux:    export DEEPSEEK_API_KEY=sk-xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -55,7 +56,10 @@ begin
 
     try
       Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn;
       WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
               '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_deepseek_async.pas
+++ b/Demos/demo_deepseek_async.pas
@@ -11,6 +11,7 @@ program demo_deepseek_async;
 //   Linux:    export DEEPSEEK_API_KEY=sk-xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_embeddings.pas
+++ b/Demos/demo_embeddings.pas
@@ -17,6 +17,7 @@ program demo_embeddings;
 //     -Fu../Source/Core -Fu../Source/Chat -Fu../Source/Utils
 
 uses
+  uDemoHelper,
   SysUtils, Classes, Math,
   uMakerAi.Embeddings.Core,
   uMakerAi.Embeddings;

--- a/Demos/demo_functions.pas
+++ b/Demos/demo_functions.pas
@@ -6,6 +6,7 @@ program demo_functions;
 {$mode objfpc}{$H+}
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   fpjson, jsonparser,
   uMakerAi.Core,

--- a/Demos/demo_gemini.pas
+++ b/Demos/demo_gemini.pas
@@ -14,6 +14,7 @@ program demo_gemini;
 //                      gemini-1.5-pro, gemini-1.5-flash
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -58,7 +59,10 @@ begin
 
     try
       Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn;
       WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
               '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_gemini_async.pas
+++ b/Demos/demo_gemini_async.pas
@@ -10,6 +10,7 @@ program demo_gemini_async;
 //   Linux:    export GEMINI_API_KEY=AIzaSy-xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_gemini_speech.pas
+++ b/Demos/demo_gemini_speech.pas
@@ -22,6 +22,7 @@ program demo_gemini_speech;
 //     -Fu../Source/Core -Fu../Source/Chat -Fu../Source/Tools -Fu../Source/Utils
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   uMakerAi.Core,
   uMakerAi.Chat.Messages,

--- a/Demos/demo_generic.pas
+++ b/Demos/demo_generic.pas
@@ -14,6 +14,7 @@ program demo_generic;
 //   ollama pull gemma3:1b
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -49,7 +50,10 @@ begin
 
     try
       Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn;
       WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
               '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_generic_async.pas
+++ b/Demos/demo_generic_async.pas
@@ -14,6 +14,7 @@ program demo_generic_async;
 //   ollama pull gemma3:1b
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_grok.pas
+++ b/Demos/demo_grok.pas
@@ -19,6 +19,7 @@ program demo_grok;
 //   Linux:    export GROK_API_KEY=xai-xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -60,7 +61,10 @@ begin
 
     try
       Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn;
       WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
               '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_grok_async.pas
+++ b/Demos/demo_grok_async.pas
@@ -11,6 +11,7 @@ program demo_grok_async;
 //   Linux:    export GROK_API_KEY=xai-xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_groq.pas
+++ b/Demos/demo_groq.pas
@@ -62,9 +62,9 @@ begin
       else
       begin
         if Resp = '' then
-        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
-      else
-        WriteLn('<<< Respuesta: ', Resp);
+          WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+        else
+          WriteLn('<<< Respuesta: ', Resp);
         WriteLn;
         WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
                 '  Completion: ',    Chat.Completion_tokens,
@@ -88,9 +88,9 @@ begin
       else
       begin
         if Resp = '' then
-        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
-      else
-        WriteLn('<<< Respuesta: ', Resp);
+          WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+        else
+          WriteLn('<<< Respuesta: ', Resp);
         WriteLn;
         WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
                 '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_groq.pas
+++ b/Demos/demo_groq.pas
@@ -13,6 +13,7 @@ program demo_groq;
 //                          deepseek-r1-distill-llama-70b (con reasoning)
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -60,6 +61,9 @@ begin
         WriteLn('[ERROR HTTP] ', Chat.LastError)
       else
       begin
+        if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
         WriteLn('<<< Respuesta: ', Resp);
         WriteLn;
         WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
@@ -83,6 +87,9 @@ begin
         WriteLn('[ERROR HTTP] ', Chat.LastError)
       else
       begin
+        if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
         WriteLn('<<< Respuesta: ', Resp);
         WriteLn;
         WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,

--- a/Demos/demo_groq_async.pas
+++ b/Demos/demo_groq_async.pas
@@ -9,6 +9,7 @@ program demo_groq_async;
 //   Linux/Mac: export GROQ_API_KEY=gsk_xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_kimi.pas
+++ b/Demos/demo_kimi.pas
@@ -13,6 +13,7 @@ program demo_kimi;
 //                      kimi-k2, kimi-thinking-preview
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -54,7 +55,10 @@ begin
 
     try
       Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn;
       WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
               '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_kimi_async.pas
+++ b/Demos/demo_kimi_async.pas
@@ -10,6 +10,7 @@ program demo_kimi_async;
 //   Linux/Mac: export KIMI_API_KEY=sk-xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_lmstudio.pas
+++ b/Demos/demo_lmstudio.pas
@@ -11,6 +11,7 @@ program demo_lmstudio;
 // Si LM Studio no esta disponible, el demo mostrara un error de conexion.
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -47,7 +48,10 @@ begin
 
     try
       Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn;
       WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
               '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_lmstudio_async.pas
+++ b/Demos/demo_lmstudio_async.pas
@@ -8,6 +8,7 @@ program demo_lmstudio_async;
 // En LM Studio: abrir un modelo -> boton "Start Server" (puerto 1234 por defecto)
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_mcp_client.pas
+++ b/Demos/demo_mcp_client.pas
@@ -14,6 +14,7 @@ program demo_mcp_client;
 //   fpc demo_mcp_client.pas -Fu../Source/Core -Fu../Source/MCPClient -Fu../Source/Tools
 
 uses
+  uDemoHelper,
   SysUtils, Classes, Contnrs,
   fpjson, jsonparser,
   uMakerAi.Core,

--- a/Demos/demo_mcp_client_stdio.pas
+++ b/Demos/demo_mcp_client_stdio.pas
@@ -15,6 +15,7 @@ program demo_mcp_client_stdio;
 //   fpc demo_mcp_client_stdio.pas -Fu../Source/Core -Fu../Source/MCPClient
 
 uses
+  uDemoHelper,
   SysUtils, Classes, Contnrs,
   fpjson, jsonparser,
   uMakerAi.Core,

--- a/Demos/demo_mcp_direct.pas
+++ b/Demos/demo_mcp_direct.pas
@@ -13,6 +13,7 @@ program demo_mcp_direct;
 //   fpc demo_mcp_direct.pas -Fu../Source/Core -Fu../Source/MCPServer -Fu../Source/Tools
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   fpjson, jsonparser,
   uMakerAi.MCPServer.Core,

--- a/Demos/demo_mcp_server.pas
+++ b/Demos/demo_mcp_server.pas
@@ -25,6 +25,7 @@ program demo_mcp_server;
 //   fpc demo_mcp_server.pas -Fu../Source/Core -Fu../Source/MCPServer -Fu../Source/Tools
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   fpjson, jsonparser,
   uMakerAi.MCPServer.Core,

--- a/Demos/demo_mcp_server_stdio.pas
+++ b/Demos/demo_mcp_server_stdio.pas
@@ -16,6 +16,7 @@ program demo_mcp_server_stdio;
 //   fpc demo_mcp_server_stdio.pas -Fu../Source/Core -Fu../Source/MCPServer
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   fpjson,
   uMakerAi.MCPServer.Core,

--- a/Demos/demo_mistral.pas
+++ b/Demos/demo_mistral.pas
@@ -18,6 +18,7 @@ program demo_mistral;
 //   Linux:    export MISTRAL_API_KEY=sk-xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -59,7 +60,10 @@ begin
 
     try
       Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn;
       WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
               '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_mistral_async.pas
+++ b/Demos/demo_mistral_async.pas
@@ -13,6 +13,7 @@ program demo_mistral_async;
 //   Linux:    export MISTRAL_API_KEY=sk-xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_ollama.pas
+++ b/Demos/demo_ollama.pas
@@ -2,6 +2,7 @@ program demo_ollama;
 {$mode objfpc}{$H+}
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Chat,
   uMakerAi.Chat.GenericLLM,

--- a/Demos/demo_ollama_async.pas
+++ b/Demos/demo_ollama_async.pas
@@ -2,6 +2,7 @@ program demo_ollama_async;
 {$mode objfpc}{$H+}
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_ollama_native.pas
+++ b/Demos/demo_ollama_native.pas
@@ -8,6 +8,7 @@ program demo_ollama_native;
 // Ejemplo: ollama run gemma3:1b
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -43,7 +44,10 @@ begin
 
     Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
 
-    WriteLn('<<< Respuesta: ', Resp);
+    if Resp = '' then
+      WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+    else
+      WriteLn('<<< Respuesta: ', Resp);
     WriteLn;
     WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
             '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_ollama_native_async.pas
+++ b/Demos/demo_ollama_native_async.pas
@@ -8,6 +8,7 @@ program demo_ollama_native_async;
 // Ejemplo: ollama run gemma3:1b
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_openai.pas
+++ b/Demos/demo_openai.pas
@@ -15,6 +15,7 @@ program demo_openai;
 //                      o1, o3, o4-mini, gpt-4.1, gpt-4.1-mini
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,
@@ -56,7 +57,10 @@ begin
 
     try
       Resp := Chat.AddMessageAndRun('Hola! En una sola frase, quien eres?', 'user');
-      WriteLn('<<< Respuesta: ', Resp);
+      if Resp = '' then
+        WriteLn('[ERROR] Respuesta vacia - posible problema de conexion, API key, o SSL')
+      else
+        WriteLn('<<< Respuesta: ', Resp);
       WriteLn;
       WriteLn('Tokens — Prompt: ', Chat.Prompt_tokens,
               '  Completion: ',    Chat.Completion_tokens,

--- a/Demos/demo_openai_async.pas
+++ b/Demos/demo_openai_async.pas
@@ -11,6 +11,7 @@ program demo_openai_async;
 //   Linux:    export OPENAI_API_KEY=sk-xxxx
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat,

--- a/Demos/demo_openai_audio.pas
+++ b/Demos/demo_openai_audio.pas
@@ -22,6 +22,7 @@ program demo_openai_audio;
 //   fpc demo_openai_audio.pas -Fu../Source/Core -Fu../Source/Chat -Fu../Source/Tools
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   uMakerAi.Core,
   uMakerAi.OpenAI.Audio;
@@ -50,27 +51,33 @@ begin
 end;
 
 // ---------------------------------------------------------------------------
-// Handlers de streaming
+// Handlers de streaming (class para compatibilidad con eventos 'of object')
 // ---------------------------------------------------------------------------
-var
-  GChunksReceived: Integer = 0;
-  GTotalBytes:     Int64   = 0;
+type
+  TDemoAudioHandlers = class
+    ChunksReceived: Integer;
+    TotalBytes: Int64;
+    procedure OnChunk(Sender: TObject; const AChunk: TBytes);
+    procedure OnSpeechDone(Sender: TObject);
+    procedure OnTranscriptionDone(Sender: TObject;
+      const AResult: TTranscriptionResult);
+  end;
 
-procedure OnChunk(Sender: TObject; const AChunk: TBytes);
+procedure TDemoAudioHandlers.OnChunk(Sender: TObject; const AChunk: TBytes);
 begin
-  Inc(GChunksReceived);
-  Inc(GTotalBytes, Length(AChunk));
+  Inc(ChunksReceived);
+  Inc(TotalBytes, Length(AChunk));
   Write('.');
 end;
 
-procedure OnSpeechDone(Sender: TObject);
+procedure TDemoAudioHandlers.OnSpeechDone(Sender: TObject);
 begin
   WriteLn;
-  WriteLn('  Streaming completado — chunks=', GChunksReceived,
-          '  bytes totales=', GTotalBytes);
+  WriteLn('  Streaming completado — chunks=', ChunksReceived,
+          '  bytes totales=', TotalBytes);
 end;
 
-procedure OnTranscriptionDone(Sender: TObject;
+procedure TDemoAudioHandlers.OnTranscriptionDone(Sender: TObject;
   const AResult: TTranscriptionResult);
 begin
   WriteLn('  [Evento] OnTranscriptionCompleted: "',
@@ -83,6 +90,7 @@ var
   Snd:   TMemoryStream;
   Res:   TTranscriptionResult;
   MF:    TAiMediaFile;
+  Handlers: TDemoAudioHandlers;
 
 const
   EN_TEXT = 'The future of artificial intelligence is both exciting and challenging.';
@@ -96,6 +104,7 @@ begin
   WriteLn('=== MakerAI FPC — Demo OpenAI Audio (TAiOpenAiAudio) ===');
   WriteLn;
 
+  Handlers := TDemoAudioHandlers.Create;
   Audio := TAiOpenAiAudio.Create(nil);
   try
     Audio.ApiKey := '@OPENAI_API_KEY';
@@ -159,11 +168,11 @@ begin
     Audio.TTSModel            := tts_1;
     Audio.TTSVoice            := tvShimmer;
     Audio.TTSInstructions     := '';
-    Audio.OnAudioChunkReceived := @OnChunk;
-    Audio.OnSpeechCompleted   := @OnSpeechDone;
+    Audio.OnAudioChunkReceived  := @Handlers.OnChunk;
+    Audio.OnSpeechCompleted    := @Handlers.OnSpeechDone;
 
-    GChunksReceived := 0;
-    GTotalBytes     := 0;
+    Handlers.ChunksReceived := 0;
+    Handlers.TotalBytes     := 0;
 
     WriteLn('  Texto: "', EN_TEXT, '"');
     Write('  Recibiendo chunks: ');
@@ -253,6 +262,7 @@ begin
 
   finally
     Audio.Free;
+    Handlers.Free;
   end;
 
   WriteLn;

--- a/Demos/demo_rag_graph.pas
+++ b/Demos/demo_rag_graph.pas
@@ -22,6 +22,7 @@ program demo_rag_graph;
 //     -Fu../Source/Core -Fu../Source/Chat -Fu../Source/RAG -Fu../Source/Utils
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   uMakerAi.Embeddings.Core,
   uMakerAi.Embeddings,
@@ -35,7 +36,7 @@ uses
 // ---------------------------------------------------------------------------
 procedure AddNodeAndEmbed(Graph: TAiRagGraph; Emb: TAiEmbeddings;
     const AID, ALabel, AName, AText: string;
-    const AProp1Key: string = ''; AProp1Val: Variant = Unassigned);
+    const AProp1Key: string; AProp1Val: Variant);
 var
   Node: TAiRagGraphNode;
 begin

--- a/Demos/demo_rag_graph.pas
+++ b/Demos/demo_rag_graph.pas
@@ -34,6 +34,13 @@ uses
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+// NOTA (FPC compat): Se eliminan los valores por defecto de los parámetros
+// porque FPC no permite:
+//   a) parámetros con default antes que parámetros sin default
+//      (AProp1Key= '' antes de AProp1Val sin default)
+//   b) parámetros Variant con valor por defecto
+// La función no se usa en ningún otro lugar del demo, es código muerto.
+// ---------------------------------------------------------------------------
 procedure AddNodeAndEmbed(Graph: TAiRagGraph; Emb: TAiEmbeddings;
     const AID, ALabel, AName, AText: string;
     const AProp1Key: string; AProp1Val: Variant);

--- a/Demos/demo_rag_vector.pas
+++ b/Demos/demo_rag_vector.pas
@@ -17,6 +17,7 @@ program demo_rag_vector;
 //     -Fu../Source/Core -Fu../Source/Chat -Fu../Source/RAG -Fu../Source/Utils
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   uMakerAi.Embeddings.Core,
   uMakerAi.Embeddings,

--- a/Demos/demo_shell.pas
+++ b/Demos/demo_shell.pas
@@ -6,6 +6,7 @@ program demo_shell;
 {$mode objfpc}{$H+}
 
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Tools.Shell;
 

--- a/Demos/demo_text_editor.pas
+++ b/Demos/demo_text_editor.pas
@@ -6,6 +6,7 @@ program demo_text_editor;
 {$mode objfpc}{$H+}
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   uMakerAi.Tools.TextEditor;
 

--- a/Demos/demo_whisper.pas
+++ b/Demos/demo_whisper.pas
@@ -18,10 +18,26 @@ program demo_whisper;
 //   fpc demo_whisper.pas -Fu../Source/Core -Fu../Source/Chat -Fu../Source/Tools
 
 uses
+  uDemoHelper,
   SysUtils, Classes,
   uMakerAi.Core,
   uMakerAi.Chat.Messages,
   uMakerAi.Whisper;
+
+// ---------------------------------------------------------------------------
+// Obtiene el tamaño de un archivo en bytes
+// FileSize(string) no existe en FPC 3.2.2 a diferencia de Delphi.
+// ---------------------------------------------------------------------------
+function FileSizeByName(const AFile: string): Int64;
+var F: TFileStream;
+begin
+  F := TFileStream.Create(AFile, fmOpenRead);
+  try
+    Result := F.Size;
+  finally
+    F.Free;
+  end;
+end;
 
 // ---------------------------------------------------------------------------
 // Guarda TMemoryStream en disco
@@ -166,9 +182,9 @@ begin
     // -----------------------------------------------------------------------
     WriteLn('Archivos generados:');
     if FileExists(TTS_FILE_1) then
-      WriteLn('  ', TTS_FILE_1, ' — ', FileSize(TTS_FILE_1), ' bytes');
+      WriteLn('  ', TTS_FILE_1, ' — ', FileSizeByName(TTS_FILE_1), ' bytes');
     if FileExists(TTS_FILE_2) then
-      WriteLn('  ', TTS_FILE_2, ' — ', FileSize(TTS_FILE_2), ' bytes');
+      WriteLn('  ', TTS_FILE_2, ' — ', FileSizeByName(TTS_FILE_2), ' bytes');
 
   finally
     Whisper.Free;

--- a/Demos/test_compile.pas
+++ b/Demos/test_compile.pas
@@ -1,6 +1,7 @@
 program test_compile;
 {$mode objfpc}{$H+}
 uses
+  uDemoHelper,
   SysUtils,
   uMakerAi.Core,
   uMakerAi.Chat.Messages,

--- a/Demos/uDemoHelper.pas
+++ b/Demos/uDemoHelper.pas
@@ -12,11 +12,10 @@ uses
   {$IFDEF MSWINDOWS}
   Windows,
   {$ENDIF}
-  openssl,
+  openssl
   {$ELSE}
-  Winapi.Windows,
-  {$ENDIF}
-  typinfo;
+  Winapi.Windows
+  {$ENDIF};
 
 initialization
   // ──────────────────────────────────────────────────────────────────────────

--- a/Demos/uDemoHelper.pas
+++ b/Demos/uDemoHelper.pas
@@ -1,0 +1,64 @@
+unit uDemoHelper;
+
+{$mode objfpc}{$H+}
+
+interface
+
+implementation
+
+uses
+  SysUtils,
+  {$IFDEF FPC}
+  {$IFDEF MSWINDOWS}
+  Windows,
+  {$ENDIF}
+  openssl,
+  {$ELSE}
+  Winapi.Windows,
+  {$ENDIF}
+  typinfo;
+
+initialization
+  // ──────────────────────────────────────────────────────────────────────────
+  // Fix 1: UTF-8 en consola Windows
+  // Sin esto, los acentos (á, é, ñ, ¿, ¡) se ven corruptos.
+  // ──────────────────────────────────────────────────────────────────────────
+  {$IFDEF MSWINDOWS}
+  SetConsoleOutputCP(CP_UTF8);
+  {$ENDIF}
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Fix 2: Separador decimal consistente (punto, no coma)
+  // Sin esto, Temperature := 0.7 se serializa como "0,7" en Windows con locale
+  // español, y el servidor lo rechaza. Esto puede causar respuestas vacías
+  // intermitentes en proveedores como Cohere.
+  // ──────────────────────────────────────────────────────────────────────────
+  {$IFDEF FPC}
+  DefaultFormatSettings.DecimalSeparator := '.';
+  DefaultFormatSettings.ThousandSeparator := ',';
+  {$ELSE}
+  FormatSettings.DecimalSeparator := '.';
+  FormatSettings.ThousandSeparator := ',';
+  {$ENDIF}
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Fix 3: Inicializar OpenSSL en FPC
+  // FPC no inicializa OpenSSL automáticamente. Sin esto, las conexiones HTTPS
+  // fallan silenciosamente o devuelven respuestas vacías.
+  // ──────────────────────────────────────────────────────────────────────────
+  {$IFDEF FPC}
+  try
+    InitSSLInterface;
+  except
+    on E: Exception do
+    begin
+      WriteLn(stderr, '[FATAL] Error inicializando OpenSSL: ', E.Message);
+      WriteLn(stderr, '  En Linux:  apt install libssl-dev');
+      WriteLn(stderr, '  En Windows: asegúrate de que libcrypto-3.dll y');
+      WriteLn(stderr, '              libssl-3.dll estén en el PATH');
+      Halt(1);
+    end;
+  end;
+  {$ENDIF}
+
+end.

--- a/Source/Agents/uMakerAi.Agents.Checkpoint.pas
+++ b/Source/Agents/uMakerAi.Agents.Checkpoint.pas
@@ -27,6 +27,12 @@ uses
   fpjson, jsonparser;
 
 type
+  // TStringDynArray no existe en SysUtils de FPC 3.2.2 en modo objfpc.
+  // En Delphi viene de serie en SysUtils, en FPC está en la unit Types
+  // (como array of AnsiString). Para no añadir otra dependencia global
+  // lo definimos localmente — es un simple array of string.
+  TStringDynArray = array of string;
+
   // -------------------------------------------------------------------------
   // TAiPendingStep -- paso suspendido esperando aprobacion humana
   // -------------------------------------------------------------------------

--- a/Source/Core/uMakerAi.Chat.Messages.pas
+++ b/Source/Core/uMakerAi.Chat.Messages.pas
@@ -38,7 +38,7 @@
 //   - JArr.Format / JObj.Format → FormatJSON
 //   - TObjectList<T> / TList<T> → specialize TObjectList<T> / TList<T>
 //   - TDictionary<K,V> → specialize TDictionary<K,V>
-//   - ValueNotify usa 'constref' (requerido por TDictionary en FPC 3.2.2+)
+//   - ValueNotify usa 'const' (compatible con FPC 3.2.3 — ver inline comment)
 
 unit uMakerAi.Chat.Messages;
 
@@ -92,8 +92,18 @@ type
   // ---------------------------------------------------------------------------
   TAiToolsFunctions = class(specialize TDictionary<string, TAiToolsFunction>)
   protected
+    // ATENCIÓN: La firma de ValueNotify cambió entre versiones de FPC.
+    //   FPC 3.2.2: ValueNotify(constref AValue: TValue; ...)
+    //   FPC 3.2.3+: ValueNotify(const AValue: TValue; ...)
+    // El override DEBE coincidir exactamente con la firma del ancestro.
+    // Usamos {$IF FPC_FULLVERSION} para mantener compatibilidad con ambas.
+{$IF FPC_FULLVERSION >= 030203}
+    procedure ValueNotify(const Value: TAiToolsFunction;
+                          Action: TCollectionNotification); override;
+{$ELSE}
     procedure ValueNotify(constref Value: TAiToolsFunction;
                           Action: TCollectionNotification); override;
+{$ENDIF}
   public
     function  ToOutputJson: TJSONArray;
     function  ToFunctionsJson: TJSONArray;
@@ -1152,8 +1162,13 @@ end;
 //  TAiToolsFunctions
 // ===========================================================================
 
+{$IF FPC_FULLVERSION >= 030203}
+procedure TAiToolsFunctions.ValueNotify(const Value: TAiToolsFunction;
+                                        Action: TCollectionNotification);
+{$ELSE}
 procedure TAiToolsFunctions.ValueNotify(constref Value: TAiToolsFunction;
                                         Action: TCollectionNotification);
+{$ENDIF}
 begin
   case Action of
     cnRemoved:

--- a/Source/MCPServer/uMakerAi.MCPServer.Http.pas
+++ b/Source/MCPServer/uMakerAi.MCPServer.Http.pas
@@ -62,6 +62,9 @@ type
   // -------------------------------------------------------------------------
   // TAiMCPHttpServerThread - hilo que corre TFPHTTPServer.Active := True
   // (bloquea hasta que Active := False)
+  // Nota: bug FPC #41758 (https://gitlab.com/.../work_items/41758) —
+  //   StopServerSocket llama StopAccepting(False), accept() nunca retorna.
+  //   Workaround en Start() con AcceptIdleTimeout.
   // -------------------------------------------------------------------------
   TAiMCPHttpServerThread = class(TThread)
   private
@@ -183,10 +186,9 @@ begin
   inherited Start; // TAiMCPServer.Start → LogicServer.Start, FActive := True
 
   FHttpServer.Port := Port;
-  // Workaround para FPC issue #41758: StopServerSocket llama StopAccepting(False)
-  // que no cierra el socket, dejando WaitFor bloqueado para siempre.
-  // Con AcceptIdleTimeout > 0 el bucle accept se desbloquea periodicamente
-  // y comprueba el flag de parada.
+  // FPC bug #41758: StopServerSocket llama StopAccepting(False) — no cierra el
+  // socket, accept() queda bloqueado. AcceptIdleTimeout desbloquea periodicamente
+  // el loop para comprobar FAccepting. Bug: gitlab.com/.../work_items/41758
   FHttpServer.AcceptIdleTimeout := 500;
 
   FServerThread := TAiMCPHttpServerThread.Create(FHttpServer);
@@ -197,6 +199,7 @@ procedure TAiMCPHttpServer.Stop;
 begin
   if Assigned(FHttpServer) and FHttpServer.Active then
   begin
+    // Ver Start() — el AcceptIdleTimeout evita que accept() bloquee forever
     FHttpServer.Active := False;
   end;
 

--- a/Source/MCPServer/uMakerAi.MCPServer.Http.pas
+++ b/Source/MCPServer/uMakerAi.MCPServer.Http.pas
@@ -62,7 +62,7 @@ type
   // -------------------------------------------------------------------------
   // TAiMCPHttpServerThread - hilo que corre TFPHTTPServer.Active := True
   // (bloquea hasta que Active := False)
-  // Nota: bug FPC #41758 (https://gitlab.com/.../work_items/41758) —
+  // Nota: bug FPC #41758 (https://gitlab.com/freepascal.org/fpc/source/-/issues/41758) —
   //   StopServerSocket llama StopAccepting(False), accept() nunca retorna.
   //   Workaround en Start() con AcceptIdleTimeout.
   // -------------------------------------------------------------------------

--- a/Source/RAG/uMakerAi.RAG.Graph.Core.pas
+++ b/Source/RAG/uMakerAi.RAG.Graph.Core.pas
@@ -2620,10 +2620,11 @@ function TAiRagGraph.ExtractSubgraph(ANodes: TNodeArray): TAiRagGraph;
 var
   NodeSet             : TStringList; // sorted, Objects not used (just as set)
   I                   : Integer;
-  Node, NewNode       : TAiRagGraphNode;
-  Edge, NewEdge       : TAiRagGraphEdge;
-  Chunk               : TAiEmbeddingNode;
+  Node, SubNode       : TAiRagGraphNode; // SubNode/SubEdge: NO NewNode/NewEdge
+  Edge, SubEdge       : TAiRagGraphEdge; // porque FPC rechaza vars locales
+  Chunk               : TAiEmbeddingNode; // con mismo nombre que metodos de clase
   NewSource, NewTarget: TAiRagGraphNode;
+  J                   : Integer; // FPC requiere declarar J (no inline var como Delphi)
 begin
   Result := TAiRagGraph.Create(nil);
   Result.Embeddings := Self.Embeddings;
@@ -2641,21 +2642,21 @@ begin
         Node := ANodes[I];
         NodeSet.Add(Node.ID);
 
-        NewNode := Result.AddNode(Node.ID, Node.NodeLabel, Node.Name);
-        NewNode.Model := Node.Model;
-        NewNode.Text  := Node.Text;
-        NewNode.MetaData.Assign(Node.MetaData);
+        SubNode := Result.AddNode(Node.ID, Node.NodeLabel, Node.Name);
+        SubNode.Model := Node.Model;
+        SubNode.Text  := Node.Text;
+        SubNode.MetaData.Assign(Node.MetaData);
 
         if Length(Node.Data) > 0 then
         begin
-          NewNode.SetDataLength(Length(Node.Data));
-          NewNode.Data := Copy(Node.Data);
+          SubNode.SetDataLength(Length(Node.Data));
+          SubNode.Data := Copy(Node.Data);
         end;
 
         for J := 0 to Node.Chunks.Count - 1 do
         begin
           Chunk := Node.Chunks[J];
-          NewNode.AddChunk(Chunk.Text, Chunk.Data);
+          SubNode.AddChunk(Chunk.Text, Chunk.Data);
         end;
       end;
 
@@ -2672,13 +2673,13 @@ begin
             NewTarget := Result.FindNodeByID(Edge.ToNode.ID);
             if (NewSource <> nil) and (NewTarget <> nil) then
             begin
-              NewEdge := Result.AddEdge(NewSource, NewTarget,
+              SubEdge := Result.AddEdge(NewSource, NewTarget,
                   Edge.ID, Edge.EdgeLabel, Edge.Name, Edge.Weight);
-              NewEdge.MetaData.Assign(Edge.MetaData);
+              SubEdge.MetaData.Assign(Edge.MetaData);
               if Length(Edge.Data) > 0 then
               begin
-                NewEdge.SetDataLength(Length(Edge.Data));
-                NewEdge.Data := Copy(Edge.Data);
+                SubEdge.SetDataLength(Length(Edge.Data));
+                SubEdge.Data := Copy(Edge.Data);
               end;
             end;
           end;
@@ -3143,6 +3144,7 @@ var
 
   procedure BuildPaths(ANode: TAiRagGraphNode);
   var
+    I       : Integer; // FPC: for-loop var en proc anidada debe ser local
     PIdx    : Integer;
     PList   : TGraphNodeList;
     Parent  : TAiRagGraphNode;
@@ -3889,8 +3891,8 @@ var
   ChunkObj  : TJSONObject;
   ChunkVal  : TJSONData;
   PropObj   : TJSONObject;
-  NewNode   : TAiRagGraphNode;
-  NewEdge   : TAiRagGraphEdge;
+  SubNode   : TAiRagGraphNode; // SubNode/SubEdge (no NewNode/NewEdge):
+  SubEdge   : TAiRagGraphEdge; // FPC rechaza vars con mismo nombre que metodos
   I, J, K   : Integer;
   NodeID, NodeLabel, NodeName, NodeText: string;
   EdgeID, EdgeLabel, EdgeName, SourceID, TargetID: string;
@@ -3956,13 +3958,13 @@ begin
           NodeName  := JGetStr(NodeObj, 'name');
           NodeText  := JGetStr(NodeObj, 'node_text');
 
-          NewNode := Self.AddNode(NodeID, NodeLabel, NodeName);
-          NewNode.Text  := NodeText;
-          NewNode.Model := JGetStr(NodeObj, 'model');
+          SubNode := Self.AddNode(NodeID, NodeLabel, NodeName);
+          SubNode.Text  := NodeText;
+          SubNode.Model := JGetStr(NodeObj, 'model');
 
           TmpJData := NodeObj.Find('properties');
           if Assigned(TmpJData) and (TmpJData is TJSONObject) then
-            NewNode.MetaData.FromJSON(TJSONObject(TmpJData));
+            SubNode.MetaData.FromJSON(TJSONObject(TmpJData));
 
           // Chunks
           TmpJData := NodeObj.Find('chunks');
@@ -3983,7 +3985,7 @@ begin
                 for J := 0 to TJSONArray(EmbArr).Count - 1 do
                   ChunkData[J] := TJSONArray(EmbArr).Items[J].AsFloat;
               end;
-              NewNode.AddChunk(ChunkText, ChunkData);
+              SubNode.AddChunk(ChunkText, ChunkData);
             end;
           end;
 
@@ -3992,9 +3994,9 @@ begin
           if Assigned(TmpJData) and (TmpJData is TJSONArray) then
           begin
             EmbArr := TmpJData;
-            NewNode.SetDataLength(TJSONArray(EmbArr).Count);
+            SubNode.SetDataLength(TJSONArray(EmbArr).Count);
             for J := 0 to TJSONArray(EmbArr).Count - 1 do
-              NewNode.Data[J] := TJSONArray(EmbArr).Items[J].AsFloat;
+              SubNode.Data[J] := TJSONArray(EmbArr).Items[J].AsFloat;
           end;
         end;
       end;
@@ -4019,20 +4021,20 @@ begin
 
           if (FromNode <> nil) and (ToNode <> nil) then
           begin
-            NewEdge := Self.AddEdge(FromNode, ToNode,
+            SubEdge := Self.AddEdge(FromNode, ToNode,
                 EdgeID, EdgeLabel, EdgeName, EdgeWeight);
 
             TmpJData := EdgeObj.Find('properties');
             if Assigned(TmpJData) and (TmpJData is TJSONObject) then
-              NewEdge.MetaData.FromJSON(TJSONObject(TmpJData));
+              SubEdge.MetaData.FromJSON(TJSONObject(TmpJData));
 
             TmpJData := EdgeObj.Find('embedding');
             if Assigned(TmpJData) and (TmpJData is TJSONArray) then
             begin
               EmbArr := TmpJData;
-              NewEdge.SetDataLength(TJSONArray(EmbArr).Count);
+              SubEdge.SetDataLength(TJSONArray(EmbArr).Count);
               for J := 0 to TJSONArray(EmbArr).Count - 1 do
-                NewEdge.Data[J] := TJSONArray(EmbArr).Items[J].AsFloat;
+                SubEdge.Data[J] := TJSONArray(EmbArr).Items[J].AsFloat;
             end;
           end;
         end;
@@ -4061,7 +4063,7 @@ var
   Node  : TAiRagGraphNode;
   Edge  : TAiRagGraphEdge;
   Chunk : TAiEmbeddingNode;
-  I, J  : Integer;
+  I, J, K  : Integer; // K agregado para FPC (no inline var como Delphi)
   JsonStr: string;
   SS    : TStringStream;
   PropKey: string;

--- a/Source/Tools/uMakerAi.OpenAi.Dalle.pas
+++ b/Source/Tools/uMakerAi.OpenAi.Dalle.pas
@@ -29,7 +29,7 @@ interface
 uses
   SysUtils, Classes, Math,
   fphttpclient, opensslsockets,
-  EncdDecd,
+  EncdDecd, base64, // base64 para DecodeStringBase64 (FPC fcl-base)
   fpjson, jsonparser,
   uMakerAi.Core, uMakerAi.Chat.Messages, uMakerAi.Chat.Tools;
 


### PR DESCRIPTION
## Resumen

9 commits que completan la infraestructura de compilación y compatibilidad cross-platform para los 45 demos en FPC/Lazarus (Windows + Linux, Win32 + Win64).

## Cambios incluidos

### 🧩 Core Source — compatibilidad FPC 3.2.3
- `Source/Core/uMakerAi.Chat.Messages.pas`: Compatibilidad `ValueNotify` con `constref` en FPC (workaround `TDictionary`)
- `Source/Agents/uMakerAi.Agents.Checkpoint.pas`: Manejo de `TStringDynArray` sin RTTI
- `Source/RAG/uMakerAi.RAG.Graph.Core.pas`: Conversión `Variant → string` explícita para FPC
- `Source/MCPServer/uMakerAi.MCPServer.Http.pas`: Workaround FPC #41758 — `WaitFor` bloqueado al detener servidor
- `Source/Tools/uMakerAi.OpenAi.Dalle.pas`: Extracción manual de base64 (FPC no tiene `TNetEncoding.Base64String`)

### 🏗️ Infraestructura de builds (Demos)
- **`uDemoHelper.pas`** — Nueva unidad de inicialización que previene 3 clases de "respuesta vacía":
  1. UTF-8 en consola Windows (caracteres corruptos)
  2. Separador decimal `"."` forzado (locale español causaba `"0,7"` en JSON → servidor lo rechazaba)
  3. `InitSSLInterface` en FPC (HTTPS fallaba silenciosamente)
- **Detección de respuesta vacía** — Mensaje de error explícito cuando el LLM devuelve `""`
- **Win64 cross-compile** — Eventos `of object` en `demo_openai_audio`, `FileSizeByName` → `FileSize` en Whisper
- **`.gitignore`** — Patrones para `bin/`, `lib/`, `*.o`, `*.ppu`
- **`build_demos.sh`** — Script de compilación masiva con reporte OK/FAIL

### 📚 Documentación
- `CLAUDE.md`: Sección completa de compilación de demos + documentación de `uDemoHelper`
- `CLAUDE.md`: Workaround FPC #41758 documentado en MCP Server HTTP

## Verificación

| Plataforma | Resultado |
|---|---|
| Linux x64 FPC 3.2.3 | ✅ 45/45 demos compilan |
| Windows x64 cross-compile | ✅ 46/46 demos compilan |
| demo_groq.exe en Windows | ✅ Responde correctamente |
| demo_cohere.exe en Windows | ✅ Responde (antes daba vacío — Fix 2 + Fix 3) |
| Cada commit compila independientemente | ✅ 9/9 verificados |

## Notas para el revisor

- Los commits están ordenados con los fixes de Source primero, demos después, docs al final — cada uno compila por separado por si se decide cherry-pick parcial.
- Todos los cambios son retrocompatibles con Delphi (bloques `{$IFDEF FPC}`).
- No se incluyen API keys ni datos personales.