### PR TITLE
fix(chat): evitar deadlock en async cuando un tool call usa TThread.Synchronize (#103)

### DIFF
--- a/Source/Chat/uMakerAi.Chat.Claude.pas
+++ b/Source/Chat/uMakerAi.Chat.Claude.pas
@@ -1408,7 +1408,10 @@ begin
         _CreateTask(ToolCall, I); // subrutina local garantiza captura por valor
         Inc(I);
       end;
-      TTask.WaitForAll(TaskList);
+      // Bombear Synchronize/Queue mientras se espera, para no colgar la app si un
+      // tool call accede a la VCL/FMX via TThread.Synchronize (issue #103).
+      while not TTask.WaitForAll(TaskList, 10) do
+        CheckSynchronize(0);
 
       var LStopLoop := False;
       for Clave in LFunciones.Keys do

--- a/Source/Chat/uMakerAi.Chat.Cohere.pas
+++ b/Source/Chat/uMakerAi.Chat.Cohere.pas
@@ -288,7 +288,10 @@ begin
 
       _CreateTask(ToolCall, I); // subrutina local garantiza captura por valor
     end;
-    TTask.WaitForAll(TaskList);
+    // Bombear Synchronize/Queue mientras se espera, para no colgar la app si un
+    // tool call accede a la VCL/FMX via TThread.Synchronize (issue #103).
+    while not TTask.WaitForAll(TaskList, 10) do
+      CheckSynchronize(0);
 
     // 2. Agregar un mensaje 'tool' por cada resultado (formato v2: tool_call_id + content)
     for ToolCall in ToolCallList do

--- a/Source/Chat/uMakerAi.Chat.Gemini.pas
+++ b/Source/Chat/uMakerAi.Chat.Gemini.pas
@@ -1657,7 +1657,10 @@ begin
         _CreateTask(ToolCall, I); // subrutina local garantiza captura por valor
         Inc(I);
       End;
-      TTask.WaitForAll(TaskList);
+      // Bombear Synchronize/Queue mientras se espera, para no colgar la app si un
+      // tool call accede a la VCL/FMX via TThread.Synchronize (issue #103).
+      while not TTask.WaitForAll(TaskList, 10) do
+        CheckSynchronize(0);
 
       // Crear los mensajes de respuesta de las herramientas
       For Clave in LFunciones.Keys do

--- a/Source/Chat/uMakerAi.Chat.Ollama.pas
+++ b/Source/Chat/uMakerAi.Chat.Ollama.pas
@@ -886,8 +886,11 @@ begin
           Inc(I);
         end;
 
-        // Esperar a que todas las funciones terminen (bloqueo controlado)
-        TTask.WaitForAll(TaskList);
+        // Esperar a que todas las funciones terminen (bloqueo controlado).
+        // Bombear Synchronize/Queue para no colgar la app si un tool call accede
+        // a la VCL/FMX via TThread.Synchronize (issue #103).
+        while not TTask.WaitForAll(TaskList, 10) do
+          CheckSynchronize(0);
 
         // A.4 Añadir los resultados de las funciones (role: tool) al historial
         for LToolCall in LFunciones.Values do

--- a/Source/Chat/uMakerAi.Chat.OpenAi.pas
+++ b/Source/Chat/uMakerAi.Chat.OpenAi.pas
@@ -1550,7 +1550,10 @@ begin
         _CreateTask(ToolCall, I); // subrutina local garantiza captura por valor
       end;
 
-      TTask.WaitForAll(TaskList);
+      // Bombear Synchronize/Queue mientras se espera, para no colgar la app si un
+      // tool call accede a la VCL/FMX via TThread.Synchronize (issue #103).
+      while not TTask.WaitForAll(TaskList, 10) do
+        CheckSynchronize(0);
 
       // Crear mensajes de respuesta de tools
       for I := 0 to ToolCalls.Count - 1 do

--- a/Source/Core/uMakerAi.Chat.pas
+++ b/Source/Core/uMakerAi.Chat.pas
@@ -2617,7 +2617,13 @@ begin
         Inc(I);
 
       End;
-      TTask.WaitForAll(TaskList);
+      // No usar TTask.WaitForAll(TaskList) directo: bloquea el hilo llamante sin
+      // bombear la cola de sincronizacion. Si un tool call usa TThread.Synchronize/
+      // TThread.Queue (p.ej. para acceder a la VCL/FMX) y este hilo es el principal,
+      // se produce un deadlock (issue #103). Esperamos con timeout y procesamos los
+      // Synchronize/Queue pendientes; CheckSynchronize es no-op fuera del main thread.
+      while not TTask.WaitForAll(TaskList, 10) do
+        CheckSynchronize(0);
 
       var LStopLoop := False;
       For Clave in LFunciones.Keys do


### PR DESCRIPTION
## Resumen

Corrige el cuelgue reportado en #103: en modo **async**, un tool call que use `TThread.Synchronize`/`TThread.Queue` (p. ej. para acceder a la VCL/FMX) bloquea la aplicación.

## Causa

`TTask.WaitForAll(TaskList)` bloquea el hilo llamante sin bombear la cola de sincronización. Si el hilo principal queda bloqueado en `WaitForAll` mientras un sub-task de tool intenta `TThread.Synchronize` hacia él, se produce un deadlock.

## Solución

Patrón propuesto por el reportante (@martijntonies):

```pascal
while not TTask.WaitForAll(TaskList, 10) do
  CheckSynchronize(0);
```

`CheckSynchronize(0)` es no-op fuera del hilo principal, por lo que es inocuo en el path async/worker y resuelve el deadlock cuando el `WaitForAll` corre en el hilo principal.

## Alcance

Aplicado en todos los sitios con el mismo patrón de ejecución de tools:

- `Source/Core/uMakerAi.Chat.pas` — clase base (cubre Mistral, Groq, Grok, DeepSeek)
- `uMakerAi.Chat.OpenAi.pas`, `uMakerAi.Chat.Claude.pas`, `uMakerAi.Chat.Cohere.pas`, `uMakerAi.Chat.Ollama.pas`, `uMakerAi.Chat.Gemini.pas` (sitio de `ParseChat`)

> Nota: el segundo sitio de Gemini (streaming) recibe el mismo fix en la rama `feature/computer-use-update`, donde está entrelazado con el refactor de computer-use.

## Verificación

- Compila limpio en Delphi 13 (`MakerAI.dpk`, Win64/Release).
- El reportante validó el patrón en async ON y OFF.

Reportado y diagnosticado por @martijntonies. ¡Gracias!

🤖 Generated with [Claude Code](https://claude.com/claude-code)