### PR TITLE
fix(#103): guard de main-thread en CheckSynchronize de los drivers restantes

### DIFF
--- a/Source/Chat/uMakerAi.Chat.Claude.pas
+++ b/Source/Chat/uMakerAi.Chat.Claude.pas
@@ -1449,8 +1449,15 @@ begin
       end;
       // Bombear Synchronize/Queue mientras se espera, para no colgar la app si un
       // tool call accede a la VCL/FMX via TThread.Synchronize (issue #103).
+      // OJO: CheckSynchronize SOLO es valido en el hilo principal; en hilos
+      // secundarios (workers Indy de un servicio headless, TTask de agentes)
+      // LANZA excepcion "CheckSynchronize called from thread X". Fuera del main
+      // thread solo esperamos. Mismo criterio que TMCPClientSSE.WaitForInitialization.
       while not TTask.WaitForAll(TaskList, 10) do
-        CheckSynchronize(0);
+        if TThread.CurrentThread.ThreadID = MainThreadID then
+          CheckSynchronize(0)
+        else
+          TThread.Sleep(10);
 
       var LStopLoop := False;
       for Clave in LFunciones.Keys do

--- a/Source/Chat/uMakerAi.Chat.Cohere.pas
+++ b/Source/Chat/uMakerAi.Chat.Cohere.pas
@@ -290,8 +290,15 @@ begin
     end;
     // Bombear Synchronize/Queue mientras se espera, para no colgar la app si un
     // tool call accede a la VCL/FMX via TThread.Synchronize (issue #103).
+    // OJO: CheckSynchronize SOLO es valido en el hilo principal; en hilos
+    // secundarios (workers Indy de un servicio headless, TTask de agentes)
+    // LANZA excepcion "CheckSynchronize called from thread X". Fuera del main
+    // thread solo esperamos. Mismo criterio que TMCPClientSSE.WaitForInitialization.
     while not TTask.WaitForAll(TaskList, 10) do
-      CheckSynchronize(0);
+      if TThread.CurrentThread.ThreadID = MainThreadID then
+        CheckSynchronize(0)
+      else
+        TThread.Sleep(10);
 
     // 2. Agregar un mensaje 'tool' por cada resultado (formato v2: tool_call_id + content)
     for ToolCall in ToolCallList do

--- a/Source/Chat/uMakerAi.Chat.Gemini.pas
+++ b/Source/Chat/uMakerAi.Chat.Gemini.pas
@@ -1667,8 +1667,15 @@ begin
       End;
       // Bombear Synchronize/Queue mientras se espera, para no colgar la app si un
       // tool call accede a la VCL/FMX via TThread.Synchronize (issue #103).
+      // OJO: CheckSynchronize SOLO es valido en el hilo principal; en hilos
+      // secundarios (workers Indy de un servicio headless, TTask de agentes)
+      // LANZA excepcion "CheckSynchronize called from thread X". Fuera del main
+      // thread solo esperamos. Mismo criterio que TMCPClientSSE.WaitForInitialization.
       while not TTask.WaitForAll(TaskList, 10) do
-        CheckSynchronize(0);
+        if TThread.CurrentThread.ThreadID = MainThreadID then
+          CheckSynchronize(0)
+        else
+          TThread.Sleep(10);
 
       // Crear los mensajes de respuesta de las herramientas
       For Clave in LFunciones.Keys do
@@ -3583,8 +3590,15 @@ begin
 
           // Bombear Synchronize/Queue mientras se espera, para no colgar la app si un
           // tool call accede a la VCL/FMX via TThread.Synchronize (issue #103).
+          // OJO: CheckSynchronize SOLO es valido en el hilo principal; en hilos
+          // secundarios (workers Indy de un servicio headless, TTask de agentes)
+          // LANZA excepcion "CheckSynchronize called from thread X". Fuera del main
+          // thread solo esperamos. Mismo criterio que TMCPClientSSE.WaitForInitialization.
           while not TTask.WaitForAll(LLocalTasks, 10) do
-            CheckSynchronize(0);
+            if TThread.CurrentThread.ThreadID = MainThreadID then
+              CheckSynchronize(0)
+            else
+              TThread.Sleep(10);
 
           for var LLocalKey in LFunciones.Keys do
           begin

--- a/Source/Chat/uMakerAi.Chat.Ollama.pas
+++ b/Source/Chat/uMakerAi.Chat.Ollama.pas
@@ -889,8 +889,15 @@ begin
         // Esperar a que todas las funciones terminen (bloqueo controlado).
         // Bombear Synchronize/Queue para no colgar la app si un tool call accede
         // a la VCL/FMX via TThread.Synchronize (issue #103).
+        // OJO: CheckSynchronize SOLO es valido en el hilo principal; en hilos
+        // secundarios (workers Indy de un servicio headless, TTask de agentes)
+        // LANZA excepcion "CheckSynchronize called from thread X". Fuera del main
+        // thread solo esperamos. Mismo criterio que TMCPClientSSE.WaitForInitialization.
         while not TTask.WaitForAll(TaskList, 10) do
-          CheckSynchronize(0);
+          if TThread.CurrentThread.ThreadID = MainThreadID then
+            CheckSynchronize(0)
+          else
+            TThread.Sleep(10);
 
         // A.4 Añadir los resultados de las funciones (role: tool) al historial
         for LToolCall in LFunciones.Values do


### PR DESCRIPTION
Completa el fix de #103 en los drivers que habian quedado con `CheckSynchronize(0)` desnudo dentro del tool-loop.

## Problema

`CheckSynchronize` **solo es valido en el hilo principal**. En hilos secundarios (workers Indy de un servidor MCP/servicio headless, `TTask` de agentes) lanza la excepcion `CheckSynchronize called from thread X, which is NOT the main thread`. El fix de #103 (PR #104) aplico el patron correcto en `OpenAi.pas` y en la base `Core/uMakerAi.Chat.pas`, pero los demas drivers se quedaron con la version desnuda.

## Cambio

Se aplica el mismo guard ya presente en `OpenAi.pas` / `Chat.pas` a los 5 sitios restantes:

- `uMakerAi.Chat.Claude.pas`
- `uMakerAi.Chat.Gemini.pas` (2 sitios: completions + streaming)
- `uMakerAi.Chat.Cohere.pas`
- `uMakerAi.Chat.Ollama.pas`

```pascal
while not TTask.WaitForAll(TaskList, 10) do
  if TThread.CurrentThread.ThreadID = MainThreadID then
    CheckSynchronize(0)
  else
    TThread.Sleep(10);
```

En el main thread se sigue bombeando la cola de `Synchronize`/`Queue` (tool calls que tocan UI); fuera del main thread solo se espera.

## Verificacion

- `MakerAI.dpk` compila limpio en Delphi 13 Florence (Win64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
