### PR TITLE
fix(jul2026): issues #114 #115 #118 #119 (leak GetModels, debug log opt-in, Claude async history, 10.4 async block)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ Source/Packages/hpp/
 /nul
 Demos/014-ChatTest/*.txt
 Demos/014-ChatTest/medios/
+
+# Graphify knowledge graph (build artifact) — PR #93 @Pedro-DAS
+graphify-out/

--- a/Source/Chat/uMakerAi.Chat.AiConnection.pas
+++ b/Source/Chat/uMakerAi.Chat.AiConnection.pas
@@ -186,6 +186,11 @@ type
     procedure RemoveFromMemory(Key: String);
     procedure NewChat;
     procedure Abort;
+    // ISSUE #115: control del log de depuracion (opt-in). Delegan en las globales
+    // MakerAiDebugLogEnabled / MakerAiDebugLogPath de uMakerAi.Chat.
+    procedure EnableDebugLog(const APath: string = '');
+    procedure DisableDebugLog;
+    function IsDebugLogEnabled: Boolean;
     function GetMessages: TJSonArray; virtual;
     function GetDriversNames: TStringList; virtual;
     function GetAvailableDrivers: TArray<string>;
@@ -1408,6 +1413,23 @@ procedure TAiChatConnection.SetComputerUseTool(const Value: TAiComputerUseTool);
 begin
   FChatTools.ComputerUseTool := Value;
   if Assigned(FChat) then FChat.ChatTools.ComputerUseTool := Value;
+end;
+
+// ISSUE #115: API comoda para el log de depuracion (opt-in).
+procedure TAiChatConnection.EnableDebugLog(const APath: string = '');
+begin
+  MakerAiDebugLogPath := APath;   // vacio = <TEMP>\makerai_debug.log
+  MakerAiDebugLogEnabled := True;
+end;
+
+procedure TAiChatConnection.DisableDebugLog;
+begin
+  MakerAiDebugLogEnabled := False;
+end;
+
+function TAiChatConnection.IsDebugLogEnabled: Boolean;
+begin
+  Result := MakerAiDebugLogEnabled;
 end;
 
 end.

--- a/Source/Chat/uMakerAi.Chat.Claude.pas
+++ b/Source/Chat/uMakerAi.Chat.Claude.pas
@@ -2412,6 +2412,7 @@ var
   I: Integer;
 begin
   Result := TStringList.Create;
+  try // ISSUE #114: si el cuerpo lanza, liberar Result para no fugarlo
 
   // 1. Determinar la URL base
   if aUrl <> '' then
@@ -2472,6 +2473,10 @@ begin
 
   finally
     Client.Free;
+  end;
+  except // ISSUE #114: el camino de error no debe dejar huerfano el Result
+    Result.Free;
+    raise;
   end;
 end;
 

--- a/Source/Chat/uMakerAi.Chat.Claude.pas
+++ b/Source/Chat/uMakerAi.Chat.Claude.pas
@@ -126,7 +126,6 @@ type
   TAiClaudeChat = Class(TAiChat)
   Private
     FStreamResponseMsg: TAiChatMessage;
-    FAsyncResMsg: TAiChatMessage; // ISSUE #105: ResMsg que RunNew dejo en FMessages (a reconciliar en async)
     FStreamContentBlocks: TObjectDictionary<Integer, TClaudeStreamContentBlock>;
     FStreamBuffer: TStringBuilder;
     FStreamLastEventType: string;
@@ -1003,11 +1002,10 @@ begin
 
     if FClient.Asynchronous then
     begin
+      // ISSUE #105/#118: el mensaje del assistant se acumula en FStreamResponseMsg durante
+      // el stream y se archiva en FMessages al cerrar (message_stop, ver OnInternalReceiveData).
+      // En async RunNew libera su propio ResMsg tras el POST, por lo que NO lo referenciamos.
       FStreamResponseMsg := TAiChatMessage.Create('', 'assistant');
-      // ISSUE #105: guardamos el ResMsg de este round. RunNew lo agrega (vacio) a
-      // FMessages tras disparar el POST async; al cerrar la respuesta del stream
-      // reconciliamos su contenido para que la conversacion quede archivada.
-      FAsyncResMsg := ResMsg;
     end;
 
     ABody := InitChatCompletions;
@@ -1918,31 +1916,25 @@ begin
           finally
             jSyntheticResponse.Free;
 
+            // ISSUE #105/#118: en async, TAiChat.RunNew LIBERA su ResMsg justo despues de
+            // disparar el POST (ver rama "if FClient.Asynchronous then ResMsg.Free" en
+            // uMakerAi.Chat.pas) y NO lo deja en FMessages. Por eso el intento previo de
+            // reconciliar con FAsyncResMsg nunca funcionaba: apuntaba a un objeto ya
+            // liberado. El mensaje del assistant se construye AQUI en MsgToProcess, asi
+            // que lo archivamos directamente cuando es la respuesta FINAL (sin tool-loop
+            // en curso: FBusy=False y sin tool_calls). Mismo patron que TAiChat/TAiOpenChat.
+            // Si hubo tool_use, ParseChat ya agrego su propio mensaje (assistant + tool),
+            // por lo que aqui MsgToProcess es descartable. Fix propuesto por @martijntonies.
             if Assigned(MsgToProcess) and (FMessages.IndexOf(MsgToProcess) = -1) then
             begin
-              // ISSUE #105: en async el assistant se llena en MsgToProcess (objeto del
-              // stream), pero el historial tiene el ResMsg vacio que agrego RunNew. Si es
-              // la respuesta FINAL (sin tool-loop en curso: FBusy=False), copiamos el
-              // contenido al placeholder para que la conversacion se archive y el modelo
-              // no repita respuestas previas. En el caso de tools, ParseChat ya agrega su
-              // propio mensaje, asi que aqui solo aplica al cierre final.
-              if (not FBusy) and Assigned(FAsyncResMsg) and (FAsyncResMsg <> MsgToProcess) and
-                 (FMessages.IndexOf(FAsyncResMsg) >= 0) then
+              if (not FBusy) and (MsgToProcess.Tool_calls = '') then
               begin
-                FAsyncResMsg.Prompt := MsgToProcess.Prompt;
-                FAsyncResMsg.Role := MsgToProcess.Role;
-                if MsgToProcess.Model <> '' then
-                  FAsyncResMsg.Model := MsgToProcess.Model;
-                FAsyncResMsg.ReasoningContent := MsgToProcess.ReasoningContent;
-                FAsyncResMsg.ThinkingSignature := MsgToProcess.ThinkingSignature;
-                FAsyncResMsg.StopReason := MsgToProcess.StopReason;
-                FAsyncResMsg.Prompt_tokens := MsgToProcess.Prompt_tokens;
-                FAsyncResMsg.Completion_tokens := MsgToProcess.Completion_tokens;
-                FAsyncResMsg.Total_tokens := MsgToProcess.Total_tokens;
-                FAsyncResMsg.Cached_tokens := MsgToProcess.Cached_tokens;
-                FAsyncResMsg := nil; // ya reconciliado
+                MsgToProcess.Id := FMessages.Count + 1;
+                FMessages.Add(MsgToProcess);
+                MsgToProcess := nil; // propiedad transferida a FMessages; no liberar abajo
               end;
-              MsgToProcess.Free;
+              if Assigned(MsgToProcess) then
+                MsgToProcess.Free;
             end;
 
             // Si ParseChat disparó un Run recursivo por tool calls, FBusy quedó True

--- a/Source/Chat/uMakerAi.Chat.Cohere.pas
+++ b/Source/Chat/uMakerAi.Chat.Cohere.pas
@@ -355,6 +355,7 @@ var
   LUri: TURI;
 begin
   Result := TStringList.Create;
+  try // ISSUE #114: si el cuerpo lanza, liberar Result para no fugarlo
   Client := TNetHTTPClient.Create(nil);
   ResponseStream := TStringStream.Create('', TEncoding.UTF8);
   try
@@ -410,6 +411,10 @@ begin
   finally
     Client.Free;
     ResponseStream.Free;
+  end;
+  except // ISSUE #114: el camino de error no debe dejar huerfano el Result
+    Result.Free;
+    raise;
   end;
 end;
 

--- a/Source/Chat/uMakerAi.Chat.Cohere.pas
+++ b/Source/Chat/uMakerAi.Chat.Cohere.pas
@@ -1285,7 +1285,7 @@ begin
   LModel := TAiChatFactory.Instance.GetBaseModel(GetDriverName, Model);
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   LResponseStream := TMemoryStream.Create;

--- a/Source/Chat/uMakerAi.Chat.Gemini.pas
+++ b/Source/Chat/uMakerAi.Chat.Gemini.pas
@@ -2140,7 +2140,7 @@ var
 begin
   Result := '';
   LHttpClient := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   LHttpClient.SynchronizeEvents := False;
 {$ENDIF}
   try

--- a/Source/Chat/uMakerAi.Chat.Groq.pas
+++ b/Source/Chat/uMakerAi.Chat.Groq.pas
@@ -386,7 +386,7 @@ begin
   Raise Exception.Create('Actualmente Groq no maneja modelos de embeddings');
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   St := TStringStream.Create('', TEncoding.UTF8);
@@ -458,7 +458,7 @@ begin
   LModel := TAiChatFactory.Instance.GetBaseModel(GetDriverName, Model);
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   LResponseStream := TMemoryStream.Create;
@@ -632,7 +632,7 @@ begin
   Result := '';
   LClient := TNetHTTPClient.Create(nil);
   try
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
     LClient.SynchronizeEvents := False;
 {$ENDIF}
     LClient.ResponseTimeout := ResponseTimeOut;

--- a/Source/Chat/uMakerAi.Chat.Mistral.pas
+++ b/Source/Chat/uMakerAi.Chat.Mistral.pas
@@ -1367,7 +1367,7 @@ begin
   LModel := TAiChatFactory.Instance.GetBaseModel(GetDriverName, Model);
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   LResponseStream := TMemoryStream.Create;

--- a/Source/Chat/uMakerAi.Chat.Ollama.pas
+++ b/Source/Chat/uMakerAi.Chat.Ollama.pas
@@ -255,6 +255,7 @@ Var
   I: Integer;
 begin
   Result := TStringList.Create;
+  try // ISSUE #114: si el cuerpo lanza, liberar Result para no fugarlo
 
   If aUrl <> '' then
     EndPointUrl := aUrl
@@ -317,6 +318,10 @@ begin
     Client.Free;
     Response.Free;
   End;
+  except // ISSUE #114: el camino de error no debe dejar huerfano el Result
+    Result.Free;
+    raise;
+  end;
 end;
 
 function TAiOllamaChat.InitChatCompletions: String;

--- a/Source/Chat/uMakerAi.Chat.Ollama.pas
+++ b/Source/Chat/uMakerAi.Chat.Ollama.pas
@@ -262,7 +262,7 @@ begin
     EndPointUrl := GlAIUrl;
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   Response := TStringStream.Create('', TEncoding.UTF8);

--- a/Source/Chat/uMakerAi.Chat.OpenAi.pas
+++ b/Source/Chat/uMakerAi.Chat.OpenAi.pas
@@ -2323,7 +2323,7 @@ begin
   LModel := TAiChatFactory.Instance.GetBaseModel(GetDriverName, Model);
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   LResponseStream := TMemoryStream.Create;

--- a/Source/Core/uMakerAi.Chat.pas
+++ b/Source/Core/uMakerAi.Chat.pas
@@ -1694,6 +1694,7 @@ Var
   I: Integer;
 begin
   Result := TStringList.Create;
+  try // ISSUE #114: si el cuerpo lanza, liberar Result para no fugarlo
 
   If aUrl <> '' then
     EndPointUrl := aUrl
@@ -1760,6 +1761,10 @@ begin
     Client.Free;
     Response.Free;
   End;
+  except // ISSUE #114: el camino de error no debe dejar huerfano el Result
+    Result.Free;
+    raise;
+  end;
 end;
 
 function TAiChat.GetTools(aToolFormat: TToolFormat): TStrings;

--- a/Source/Core/uMakerAi.Chat.pas
+++ b/Source/Core/uMakerAi.Chat.pas
@@ -602,38 +602,67 @@ type
 
   // procedure Register;
 
+var
+  // ISSUE #115: control del log de depuracion. Opt-in: por defecto NO escribe.
+  // El integrador lo activa con TAiChatConnection.EnableDebugLog o poniendo esta
+  // global en True. MakerAiDebugLogPath vacio = <TEMP>\makerai_debug.log.
+  MakerAiDebugLogEnabled: Boolean = False;
+  MakerAiDebugLogPath: string = '';
+
 procedure LogDebug(const Mensaje: string);
 
 implementation
 
-uses uMakerAi.ParamsRegistry, System.IOUtils, uMakerAi.Memory.Types;
+uses uMakerAi.ParamsRegistry, System.IOUtils, System.SyncObjs, uMakerAi.Memory.Types;
 
 { TAiChat }
 
 Const
   GlOpenAIUrl = 'https://api.openai.com/v1/';
 
+var
+  GLogLock: TCriticalSection; // ISSUE #115: serializa las escrituras del log
+
 procedure LogDebug(const Mensaje: string);
 var
-  Archivo: TextFile;
-  RutaLog: string;
-  LOpened: Boolean;
+  FS: TFileStream;
+  Bytes: TBytes;
+  RutaLog, Linea: string;
 begin
-  LOpened := False;
+  // ISSUE #115: opt-in. Por defecto no hace nada (sin coste ni escritura a disco).
+  if not MakerAiDebugLogEnabled then
+    Exit;
   try
-    RutaLog := TPath.Combine(TPath.GetTempPath, 'ialog.txt');
-    AssignFile(Archivo, RutaLog);
-    if FileExists(RutaLog) then
-      Append(Archivo)
+    if MakerAiDebugLogPath <> '' then
+      RutaLog := MakerAiDebugLogPath
     else
-      Rewrite(Archivo);
-    LOpened := True;
-    WriteLn(Archivo, Mensaje);
+      RutaLog := TPath.Combine(TPath.GetTempPath, 'makerai_debug.log');
+
+    // Timestamp ISO con milisegundos + UTF-8 (TextFile perdia lineas con caracteres
+    // fuera de cp1252 y no es thread-safe).
+    Linea := FormatDateTime('yyyy-mm-dd"T"hh:nn:ss.zzz', Now) + '  ' + Mensaje + sLineBreak;
+    Bytes := TEncoding.UTF8.GetBytes(Linea);
+
+    // Serializar: varios chats async pueden llamar desde hilos distintos.
+    GLogLock.Enter;
+    try
+      if TFile.Exists(RutaLog) then
+        FS := TFileStream.Create(RutaLog, fmOpenReadWrite or fmShareDenyWrite)
+      else
+        FS := TFileStream.Create(RutaLog, fmCreate or fmShareDenyWrite);
+      try
+        FS.Seek(Int64(0), soEnd);
+        if Length(Bytes) > 0 then
+          FS.WriteBuffer(Bytes[0], Length(Bytes));
+      finally
+        FS.Free;
+      end;
+    finally
+      GLogLock.Leave;
+    end;
   except
-    // Función de depuración — nunca propaga errores al caller
+    // Funcion de depuracion — nunca propaga errores al caller.
   end;
-  if LOpened then
-    CloseFile(Archivo);
 end;
 
 procedure TAiChat.Abort;
@@ -4291,5 +4320,11 @@ begin
     end;
   end;
 end;
+
+initialization
+  GLogLock := TCriticalSection.Create; // ISSUE #115
+
+finalization
+  GLogLock.Free;
 
 end.

--- a/Source/Core/uMakerAi.Chat.pas
+++ b/Source/Core/uMakerAi.Chat.pas
@@ -1435,8 +1435,12 @@ begin
 
   FResponse := TStringStream.Create('', TEncoding.UTF8);
   FClient := TNetHTTPClient.Create(Self);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34} // ISSUE #119: SynchronizeEvents ya existe en 10.4 Sydney.
+  // Sin esto, en 10.4 los eventos del TNetHTTPClient corren en el hilo principal
+  // (SynchronizeEvents=True por defecto) y los tool calls async bloquean la UI.
   FClient.SynchronizeEvents := False;
+{$ENDIF}
+{$IF CompilerVersion >= 35}
   FClient.OnRequestException := Self.OnRequestExceptionEvent;
 {$ENDIF}
   FClient.OnReceiveData := Self.OnInternalReceiveData;
@@ -2803,7 +2807,7 @@ begin
   try
     LClient := TNetHTTPClient.Create(nil);
     try
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
       LClient.SynchronizeEvents := False;
 {$ENDIF}
       LClient.CustomHeaders['Authorization'] := 'Bearer ' + ApiKey;

--- a/Source/Embeddings/uMakerAi.Embeddings.Generic.pas
+++ b/Source/Embeddings/uMakerAi.Embeddings.Generic.pas
@@ -139,7 +139,7 @@ begin
   sUrl := FUrl.TrimRight(['/']) + '/embeddings';
 
   Client := TNetHTTPClient.Create(nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   StReq  := TStringStream.Create('', TEncoding.UTF8);

--- a/Source/Embeddings/uMakerAi.Embeddings.Mistral.pas
+++ b/Source/Embeddings/uMakerAi.Embeddings.Mistral.pas
@@ -90,7 +90,7 @@ Var
 begin
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   St := TStringStream.Create('', TEncoding.UTF8);

--- a/Source/Embeddings/uMakerAi.Embeddings.Ollama.pas
+++ b/Source/Embeddings/uMakerAi.Embeddings.Ollama.pas
@@ -106,7 +106,7 @@ begin
     aDimensions := FDimensions;
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   St := TStringStream.Create('', TEncoding.UTF8);

--- a/Source/Embeddings/uMakerAi.Embeddings.OpenAi.pas
+++ b/Source/Embeddings/uMakerAi.Embeddings.OpenAi.pas
@@ -90,7 +90,7 @@ Var
 begin
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   St := TStringStream.Create('', TEncoding.UTF8);

--- a/Source/Embeddings/uMakerAi.Embeddings.pas
+++ b/Source/Embeddings/uMakerAi.Embeddings.pas
@@ -171,7 +171,7 @@ begin
   end;
 
   Client := TNetHTTPClient.Create(nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   RequestStream := TStringStream.Create('', TEncoding.UTF8);

--- a/Source/Tools/uMakerAi.Gemini.Veo.pas
+++ b/Source/Tools/uMakerAi.Gemini.Veo.pas
@@ -680,7 +680,7 @@ begin
   Result := '';
   LHttpClient := TNetHTTPClient.Create(Nil);
 
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   LHttpClient.SynchronizeEvents := False;
 {$ENDIF}
   try

--- a/Source/Tools/uMakerAi.Whisper.pas
+++ b/Source/Tools/uMakerAi.Whisper.pas
@@ -371,7 +371,7 @@ begin
   /// PCM: Similar to WAV but containing the raw samples in 24kHz (16-bit signed, low-endian), without the header.
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   St := TStringStream.Create('', TEncoding.UTF8);
@@ -451,7 +451,7 @@ begin
   sUrl := FUrl + 'audio/transcriptions';
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   Headers := [TNetHeader.Create('Authorization', 'Bearer ' + ApiKey)];
@@ -526,7 +526,7 @@ begin
   sUrl := FUrl + 'audio/translations';
 
   Client := TNetHTTPClient.Create(Nil);
-{$IF CompilerVersion >= 35}
+{$IF CompilerVersion >= 34}
   Client.SynchronizeEvents := False;
 {$ENDIF}
   Headers := [TNetHeader.Create('Authorization', 'Bearer ' + FApiKey)];


### PR DESCRIPTION
Resuelve los 4 issues abiertos reportados por @martijntonies y @soporte-defontsoft. ¡Gracias por los diagnósticos tan detallados!

## Cambios

- **Closes #119** — Async: en Delphi 10.4 el guard `{$IF CompilerVersion >= 35}` dejaba `SynchronizeEvents` en su valor por defecto (`True`), así que los eventos del `TNetHTTPClient` (y los tool calls que dispara `ParseChat`) corrían en el hilo principal, bloqueando la UI. Se baja el guard a `>= 34` en los 19 sitios (10.4 sí soporta `SynchronizeEvents`). `OnRequestException` se separa a su propio guard `>= 35` (su disponibilidad en 10.4 no está confirmada). *Verificación runtime en 10.4 pendiente (aquí compila en Delphi 13).*

- **Closes #118** — Claude async no archivaba el assistant (el fix previo de #105 no funcionaba). Causa real: en async, `TAiChat.RunNew` **libera** su `ResMsg` justo tras el POST y **no** lo deja en `FMessages`, por lo que la reconciliación contra `FAsyncResMsg` apuntaba a memoria liberada. Ahora el assistant (construido en `FStreamResponseMsg` durante el stream) se archiva directo en `FMessages` al cerrar, cuando es la respuesta final (`FBusy=False` y `Tool_calls=''`). **Validado en runtime** con `Demos/068-AsyncHistoryTest` (claude-opus-4-8, async, 3 turnos): el modelo recuerda el contexto previo.

- **Closes #114** — `GetModels` filtraba el `TStringList` del `Result` en el camino de error (creado antes del `try/finally` que solo libera HTTP). Se envuelve el cuerpo en `try/except Result.Free; raise;` en los 4 sitios (base + Claude + Cohere + Ollama).

- **Closes #115** — Debug log **opt-in** (default OFF): globales `MakerAiDebugLogEnabled` / `MakerAiDebugLogPath`, `LogDebug` con guarda + `TFileStream` UTF-8 + timestamp ISO ms + `TCriticalSection` (thread-safe), y API `EnableDebugLog`/`DisableDebugLog`/`IsDebugLogEnabled` en `TAiChatConnection`. **Cambio de comportamiento:** el log ya no escribe por defecto; hay que llamar `EnableDebugLog`.

## Verificación

- `MakerAI.dpk` compila limpio en Delphi 13 Florence (Win64) tras cada fix.
- #118 validado en runtime (demo 068).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
