### PR TITLE
docs: add optional Parallel Search MCP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,25 @@ Full **dual-era** implementation of the MCP standard for both consuming and expo
 - Connect to Claude Desktop tools, filesystem servers, database tools, etc.
 - Integrated into `TAiFunctions` component alongside native function definitions
 
+Optional example using the native HTTP client with [Parallel Search](https://search.parallel.ai/mcp):
+
+```pascal
+var
+  MCPClient: TMCPClientHttp;
+begin
+  MCPClient := TMCPClientHttp.Create(nil);
+  try
+    MCPClient.URL := 'https://search.parallel.ai/mcp';
+    if MCPClient.Initialize then
+      Writeln(MCPClient.Tools.Text);
+  finally
+    MCPClient.Free;
+  end;
+end;
+```
+
+Parallel Search is optional and free to use without an API key. When selected, it receives the user-selected search queries and any URLs requested for fetching.
+
 > **⚠️ SSE transport deprecation (spec 2026-07-28):** the classic HTTP+SSE transport (GET `/sse` + POST `/messages`) was formally moved to *Deprecated* state by MCP spec revision 2026-07-28 under the project's feature-lifecycle policy, which mandates a minimum 12-month window. Its **earliest possible removal from the spec is July 2027** — actual removal happens in the first spec revision published after that date, at the maintainers' discretion, and may come later. Removal deletes the transport from future spec revisions only: existing MakerAI SSE endpoints keep working between themselves, but third-party clients (Claude Desktop, official SDKs) will progressively drop it. **Use the HTTP or StdIO transports for anything new.** Note that SSE *as a streaming response format* survives inside Streamable HTTP — only the standalone HTTP+SSE transport is being retired.
 
 ### 🛠️ ChatTools — AI × Deterministic Capabilities


### PR DESCRIPTION
## Why

MakerAI users can connect its native HTTP MCP client to an optional hosted search and URL-fetching tool without adding dependencies or configuring an API key.

## Changes

- Add a `TMCPClientHttp` example for the Parallel Search MCP endpoint in the existing MCP Client section.
- Note that the service is optional, free without an API key, and receives user-selected queries and requested URLs.
- Leave existing clients, providers, defaults, local settings, and dependencies unchanged.

## Validation

- `git diff --check -- README.md`: passed.
- `git status --short` and README-only path/numstat checks: passed; only `README.md` changed, with 19 additions and no deletions.
- Documentation-only limitation: the hosted endpoint was not invoked and the Delphi example was not compiled.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.